### PR TITLE
fix(chatwoot): support CSAT messages in webhook processing

### DIFF
--- a/src/apps/chatwoot/consumers/inbox/message_created.ts
+++ b/src/apps/chatwoot/consumers/inbox/message_created.ts
@@ -80,7 +80,7 @@ export class MessageHandler {
   async handle(body: any) {
     const chatId = await LookupAndCheckChatId(this.session, body);
     const message = body;
-    if (message.content_type != 'text') {
+    if (message.content_type != 'text' && message.content_type != 'input_csat') {
       this.logger.info(
         `Message content type not supported. Content type: ${message.content_type}`,
       );


### PR DESCRIPTION
- Add support for 'input_csat' content_type in MessageHandler
- Previously CSAT messages were being ignored due to strict content_type check
- CSAT messages now processed as text messages and sent to WhatsApp
- Fixes issue where Chatwoot CSAT surveys were not being delivered to users

Changes:
- Modified content_type validation in message_created.ts to accept both 'text' and 'input_csat'
- CSAT messages will now be sent to WhatsApp with their survey content and links
- Maintains existing behavior for all other message types

Related to https://github.com/devlikeapro/waha/issues/1228

[![patron:PRO](https://img.shields.io/badge/patron-PRO-188a42)](https://waha.devlike.pro/docs/how-to/plus-version/#tiers)