### PR TITLE
[CORE] Add automatic presence management and activity tracking

### DIFF
--- a/src/core/abc/session.abc.ts
+++ b/src/core/abc/session.abc.ts
@@ -195,6 +195,14 @@ export abstract class WhatsappSession {
     stdTTL: 10 * 60, // 10 minutes
   });
 
+  // Activity tracking
+  private lastActivityTimestamp?: number;
+  private presenceOfflineTimeout?: ReturnType<typeof setTimeout>;
+  private isPresenceOnlineActive: boolean = false;
+
+  // Time that stays ONLINE before going back to OFFLINE (60 seconds)
+  private PRESENCE_ONLINE_DURATION_MS = 60_000; // 60 seconds
+
   public mediaConverter: IMediaConverter = new CoreMediaConverter();
 
   public constructor({
@@ -308,6 +316,17 @@ export abstract class WhatsappSession {
       return;
     }
     this._status = value;
+    
+    // Update activity when session becomes WORKING
+    if (value === WAHASessionStatus.WORKING) {
+      this.updateActivity();
+    }
+    
+    // Cleanup presence timeout when session stops
+    if (value === WAHASessionStatus.STOPPED) {
+      this.cleanupPresenceTimeout();
+    }
+    
     this.status$.next(value);
   }
 
@@ -533,9 +552,86 @@ export abstract class WhatsappSession {
 
   abstract sendSeen(chat: SendSeenRequest);
 
-  abstract startTyping(chat: ChatRequest);
+  abstract startTyping(chat: ChatRequest): Promise<void>;
 
   abstract stopTyping(chat: ChatRequest);
+
+  /**
+   * Activity tracking and presence management
+   */
+
+  /**
+   * Updates the last activity timestamp
+   * Called whenever there is real interaction with WhatsApp
+   */
+  protected updateActivity() {
+    this.lastActivityTimestamp = Date.now();
+  }
+
+  /**
+   * Returns the timestamp of the last activity of the session
+   * @returns Timestamp in milliseconds or undefined if there was never any activity
+   */
+  public getLastActivityTimestamp(): number | undefined {
+    return this.lastActivityTimestamp;
+  }
+
+  /**
+   * Maintains ONLINE presence active while there is activity
+   * Resets the timer on each activity, only goes OFFLINE after 60s without activity
+   */
+  protected async maintainPresenceOnline(): Promise<void> {
+    if (this.status !== WAHASessionStatus.WORKING) {
+      return;
+    }
+
+    // If not ONLINE yet, send ONLINE
+    if (!this.isPresenceOnlineActive) {
+      try {
+        await this.setPresence(WAHAPresenceStatus.ONLINE);
+        this.isPresenceOnlineActive = true;
+        this.logger.debug('Set presence to ONLINE due to activity');
+      } catch (error) {
+        this.logger.debug('Failed to set presence ONLINE', error);
+        return;
+      }
+    }
+
+    // Cancel the previous timeout (if exists)
+    if (this.presenceOfflineTimeout) {
+      clearTimeout(this.presenceOfflineTimeout);
+    }
+
+    // Schedule to go back OFFLINE after 60 seconds without activity
+    this.presenceOfflineTimeout = setTimeout(async () => {
+      try {
+        if (
+          this.status === WAHASessionStatus.WORKING &&
+          this.isPresenceOnlineActive
+        ) {
+          await this.setPresence(WAHAPresenceStatus.OFFLINE);
+          this.isPresenceOnlineActive = false;
+          this.logger.debug(
+            'Auto-set presence to OFFLINE after 60s without activity',
+          );
+        }
+      } catch (error) {
+        this.logger.debug('Failed to set presence OFFLINE', error);
+      }
+      this.presenceOfflineTimeout = null;
+    }, this.PRESENCE_ONLINE_DURATION_MS);
+  }
+
+  /**
+   * Cleans up the timeout when the session stops
+   */
+  protected cleanupPresenceTimeout() {
+    if (this.presenceOfflineTimeout) {
+      clearTimeout(this.presenceOfflineTimeout);
+      this.presenceOfflineTimeout = null;
+    }
+    this.isPresenceOnlineActive = false;
+  }
 
   abstract setReaction(request: MessageReactionRequest);
 

--- a/src/core/engines/gows/session.gows.core.ts
+++ b/src/core/engines/gows/session.gows.core.ts
@@ -678,6 +678,7 @@ export class WhatsappSessionGoWSCore extends WhatsappSession {
   }
 
   async stop(): Promise<void> {
+    this.cleanupPresenceTimeout();
     if (this.client) {
       const response = await promisify(this.client.StopSession)(this.session);
       response.toObject();
@@ -792,6 +793,8 @@ export class WhatsappSessionGoWSCore extends WhatsappSession {
   }
 
   async sendText(request: MessageTextRequest) {
+    await this.maintainPresenceOnline();
+    this.updateActivity();
     const jid = toJID(this.ensureSuffix(request.chatId));
     const message = new messages.MessageRequest({
       jid: jid,
@@ -827,6 +830,8 @@ export class WhatsappSessionGoWSCore extends WhatsappSession {
   }
 
   async sendContactVCard(request: MessageContactVcardRequest) {
+    await this.maintainPresenceOnline();
+    this.updateActivity();
     const jid = toJID(this.ensureSuffix(request.chatId));
     const contacts = request.contacts.map((el) => ({ vcard: toVcardV3(el) }));
     const message = new messages.MessageRequest({
@@ -841,6 +846,8 @@ export class WhatsappSessionGoWSCore extends WhatsappSession {
   }
 
   async sendPoll(request: MessagePollRequest) {
+    await this.maintainPresenceOnline();
+    this.updateActivity();
     const jid = toJID(request.chatId);
     const message = new messages.MessageRequest({
       jid: jid,
@@ -956,6 +963,8 @@ export class WhatsappSessionGoWSCore extends WhatsappSession {
   }
 
   async sendLocation(request: MessageLocationRequest) {
+    await this.maintainPresenceOnline();
+    this.updateActivity();
     const jid = toJID(this.ensureSuffix(request.chatId));
     const message = new messages.MessageRequest({
       jid: jid,
@@ -999,6 +1008,8 @@ export class WhatsappSessionGoWSCore extends WhatsappSession {
   }
 
   async sendSeen(request: SendSeenRequest) {
+    await this.maintainPresenceOnline();
+    this.updateActivity();
     const keys = ExtractMessageKeysForRead(request);
     if (keys.length === 0) {
       return;
@@ -1020,8 +1031,10 @@ export class WhatsappSessionGoWSCore extends WhatsappSession {
     return;
   }
 
-  startTyping(chat: ChatRequest) {
-    return this.setPresence(WAHAPresenceStatus.TYPING, chat.chatId);
+  async startTyping(chat: ChatRequest): Promise<void> {
+    await this.maintainPresenceOnline();
+    this.updateActivity();
+    await this.setPresence(WAHAPresenceStatus.TYPING, chat.chatId);
   }
 
   stopTyping(chat: ChatRequest) {
@@ -1225,6 +1238,8 @@ export class WhatsappSessionGoWSCore extends WhatsappSession {
   }
 
   async setReaction(request: MessageReactionRequest) {
+    await this.maintainPresenceOnline();
+    this.updateActivity();
     const key = parseMessageIdSerialized(request.messageId);
     const message = new messages.MessageReaction({
       session: this.session,

--- a/src/core/engines/noweb/session.noweb.core.ts
+++ b/src/core/engines/noweb/session.noweb.core.ts
@@ -722,6 +722,7 @@ export class WhatsappSessionNoWebCore extends WhatsappSession {
   }
 
   private async end() {
+    this.cleanupPresenceTimeout();
     this.autoRestartJob.stop();
     // @ts-ignore
     this.sock?.ev?.removeAllListeners();
@@ -845,6 +846,8 @@ export class WhatsappSessionNoWebCore extends WhatsappSession {
   }
 
   async sendText(request: MessageTextRequest) {
+    await this.maintainPresenceOnline();
+    this.updateActivity();
     const chatId = toJID(this.ensureSuffix(request.chatId));
     const message = {
       text: request.text,
@@ -886,6 +889,8 @@ export class WhatsappSessionNoWebCore extends WhatsappSession {
   }
 
   async sendContactVCard(request: MessageContactVcardRequest) {
+    await this.maintainPresenceOnline();
+    this.updateActivity();
     const chatId = toJID(this.ensureSuffix(request.chatId));
     const contacts = request.contacts.map((el) => ({ vcard: toVcardV3(el) }));
     const options = await this.getMessageOptions(request);
@@ -894,6 +899,8 @@ export class WhatsappSessionNoWebCore extends WhatsappSession {
   }
 
   async sendPoll(request: MessagePollRequest) {
+    await this.maintainPresenceOnline();
+    this.updateActivity();
     const requestPoll = request.poll;
     const poll = {
       name: requestPoll.name,
@@ -910,6 +917,8 @@ export class WhatsappSessionNoWebCore extends WhatsappSession {
   }
 
   async reply(request: MessageReplyRequest) {
+    await this.maintainPresenceOnline();
+    this.updateActivity();
     const options = await this.getMessageOptions(request);
     const message = {
       text: request.text,
@@ -947,6 +956,8 @@ export class WhatsappSessionNoWebCore extends WhatsappSession {
   }
 
   async sendButtons(request: SendButtonsRequest) {
+    await this.maintainPresenceOnline();
+    this.updateActivity();
     const chatId = toJID(this.ensureSuffix(request.chatId));
     const headerImage = await this.uploadMedia(request.headerImage, 'image');
     return await sendButtonMessage(
@@ -965,6 +976,8 @@ export class WhatsappSessionNoWebCore extends WhatsappSession {
   }
 
   async sendLocation(request: MessageLocationRequest) {
+    await this.maintainPresenceOnline();
+    this.updateActivity();
     const chatId = toJID(this.ensureSuffix(request.chatId));
     const msg = {
       location: {
@@ -996,6 +1009,8 @@ export class WhatsappSessionNoWebCore extends WhatsappSession {
   }
 
   async sendLinkPreview(request: MessageLinkPreviewRequest) {
+    await this.maintainPresenceOnline();
+    this.updateActivity();
     const text = `${request.title}\n${request.url}`;
     const chatId = toJID(this.ensureSuffix(request.chatId));
     const msg = { text: text };
@@ -1004,6 +1019,8 @@ export class WhatsappSessionNoWebCore extends WhatsappSession {
   }
 
   async sendSeen(request: SendSeenRequest) {
+    await this.maintainPresenceOnline();
+    this.updateActivity();
     const keys = ExtractMessageKeysForRead(request);
     if (keys.length === 0) {
       return;
@@ -1020,9 +1037,11 @@ export class WhatsappSessionNoWebCore extends WhatsappSession {
     this.sock?.ev.emit('messages.update', updates);
   }
 
-  async startTyping(request: ChatRequest) {
+  async startTyping(request: ChatRequest): Promise<void> {
+    await this.maintainPresenceOnline();
+    this.updateActivity();
     const chatId = toJID(this.ensureSuffix(request.chatId));
-    return this.sock.sendPresenceUpdate('composing', chatId);
+    await this.sock.sendPresenceUpdate('composing', chatId);
   }
 
   async stopTyping(request: ChatRequest) {
@@ -1099,6 +1118,8 @@ export class WhatsappSessionNoWebCore extends WhatsappSession {
   }
 
   async setReaction(request: MessageReactionRequest) {
+    await this.maintainPresenceOnline();
+    this.updateActivity();
     const key = parseMessageIdSerialized(request.messageId);
     if (isJidNewsletter(key.remoteJid)) {
       let serverId = Number(key.id);

--- a/src/core/engines/webjs/session.webjs.core.ts
+++ b/src/core/engines/webjs/session.webjs.core.ts
@@ -363,6 +363,7 @@ export class WhatsappSessionWebJSCore extends WhatsappSession {
   }
 
   async stop() {
+    this.cleanupPresenceTimeout();
     this.shouldRestart = false;
     this.status = WAHASessionStatus.STOPPED;
     this.stopEvents();
@@ -667,6 +668,8 @@ export class WhatsappSessionWebJSCore extends WhatsappSession {
   }
 
   async sendContactVCard(request: MessageContactVcardRequest) {
+    await this.maintainPresenceOnline();
+    this.updateActivity();
     const chatId = this.ensureSuffix(request.chatId);
     const vcards = request.contacts.map((el) => toVcardV3(el as any));
     const options = this.getMessageOptions(request);
@@ -688,7 +691,9 @@ export class WhatsappSessionWebJSCore extends WhatsappSession {
     return this.whatsapp.sendMessage(chatId, '', { ...options, extra });
   }
 
-  reply(request: MessageReplyRequest) {
+  async reply(request: MessageReplyRequest) {
+    await this.maintainPresenceOnline();
+    this.updateActivity();
     const options = this.getMessageOptions(request);
     return this.whatsapp.sendMessage(
       this.ensureSuffix(request.chatId),
@@ -714,6 +719,8 @@ export class WhatsappSessionWebJSCore extends WhatsappSession {
   }
 
   async sendLocation(request: MessageLocationRequest) {
+    await this.maintainPresenceOnline();
+    this.updateActivity();
     const location = new Location(request.latitude, request.longitude, {
       name: request.title,
     });
@@ -735,13 +742,17 @@ export class WhatsappSessionWebJSCore extends WhatsappSession {
   }
 
   async sendSeen(request: SendSeenRequest) {
+    await this.maintainPresenceOnline();
+    this.updateActivity();
     const chat: Chat = await this.whatsapp.getChatById(
       this.ensureSuffix(request.chatId),
     );
     await chat.sendSeen();
   }
 
-  async startTyping(request: ChatRequest) {
+  async startTyping(request: ChatRequest): Promise<void> {
+    await this.maintainPresenceOnline();
+    this.updateActivity();
     const chat: Chat = await this.whatsapp.getChatById(
       this.ensureSuffix(request.chatId),
     );

--- a/src/core/manager.core.ts
+++ b/src/core/manager.core.ts
@@ -367,6 +367,7 @@ export class SessionManagerCore extends SessionManager implements OnModuleInit {
         status: session.status,
         config: session.sessionConfig,
         me: me,
+        lastActivityTimestamp: session?.getLastActivityTimestamp(),
       },
     ];
   }
@@ -400,7 +401,11 @@ export class SessionManagerCore extends SessionManager implements OnModuleInit {
     }
     const session = sessions[0];
     const engine = await this.fetchEngineInfo();
-    return { ...session, engine: engine };
+    return {
+      ...session,
+      engine: engine,
+      lastActivityTimestamp: session.lastActivityTimestamp,
+    };
   }
 
   protected stopEvents() {

--- a/src/structures/sessions.dto.ts
+++ b/src/structures/sessions.dto.ts
@@ -237,6 +237,7 @@ export class MeInfo {
 export class SessionInfo extends SessionDTO {
   me?: MeInfo;
   assignedWorker?: string;
+  lastActivityTimestamp?: number; // Timestamp of the last activity in milliseconds
 }
 
 export class SessionDetailedInfo extends SessionInfo {


### PR DESCRIPTION
- Add activity tracking (lastActivityTimestamp) to monitor real interactions
- Implement maintainPresenceOnline() to keep session active during activity
- Automatically send ONLINE presence when activity occurs
- Automatically return to OFFLINE after 60 seconds without activity
- Add lastActivityTimestamp field to SessionInfo API response
- Implement in all engines (NOWEB, GOWS, WEBJS)
- Cleanup presence timeout when session stops

This prevents WhatsApp from disconnecting sessions due to inactivity by signaling activity through presence updates while avoiding constant online status that could generate unnecessary notifications.

[![patron:PRO](https://img.shields.io/badge/patron-PRO-188a42)](https://waha.devlike.pro/docs/how-to/plus-version/#tiers)

issue: https://github.com/devlikeapro/waha/issues/1584

Please check if this is feasible; I'm already using it and it works.