### PR TITLE
Fix ChatWoot escaped newlines normalization

### DIFF
--- a/src/apps/chatwoot/messages/to/whatsapp/markdown.test.ts
+++ b/src/apps/chatwoot/messages/to/whatsapp/markdown.test.ts
@@ -51,4 +51,44 @@ describe('MarkdownToWhatsApp', () => {
       'Links: https://example.com/page_1 e https://example.com/page_2',
     );
   });
+
+  it('normalizes escaped newlines from ChatWoot', () => {
+    // Test case: ChatWoot sends \\\n (literal: backslash, backslash, backslash, n) instead of \n
+    // Using String.raw to represent literal characters: \ + \ + \ + n
+    const input = String.raw`djaskldlaksj \\\n \\\n \\\ndkasldjlaskj \\\n \\\ndaksldkajlsk`;
+    const expected = 'djaskldlaksj \n \n \ndkasldjlaskj \n \ndaksldkajlsk';
+    expect(MarkdownToWhatsApp(input)).toBe(expected);
+  });
+
+  it('normalizes multiple escaped newlines', () => {
+    // Test case with multiple escaped newlines
+    // \\\n = \ + \ + \ + n (3 backslashes), \\\\\n = \ + \ + \ + \ + n (4 backslashes)
+    const input = String.raw`text1 \\\n text2 \\\\\n text3`;
+    const expected = 'text1 \n text2 \n text3';
+    expect(MarkdownToWhatsApp(input)).toBe(expected);
+  });
+
+  it('normalizes even number of escaped backslashes', () => {
+    // Test case: 4 backslashes (even number) followed by n
+    // In String.raw: \\\\n = 4 backslashes + n
+    const input = String.raw`text \\\\n more text`;
+    const expected = 'text \n more text';
+    expect(MarkdownToWhatsApp(input)).toBe(expected);
+  });
+
+  it('normalizes odd number of escaped backslashes', () => {
+    // Test case: 5 backslashes (odd number) followed by n
+    // In String.raw: \\\\\n = 5 backslashes + n
+    const input = String.raw`text \\\\\n more text`;
+    const expected = 'text \n more text';
+    expect(MarkdownToWhatsApp(input)).toBe(expected);
+  });
+
+  it('does not normalize single backslash followed by n', () => {
+    // Test case: single backslash + n should NOT be normalized (legitimate newline)
+    // In String.raw: \n represents a single backslash + n
+    const input = String.raw`text \n more text`;
+    const expected = String.raw`text \n more text`; // Should remain unchanged
+    expect(MarkdownToWhatsApp(input)).toBe(expected);
+  });
 });

--- a/src/apps/chatwoot/messages/to/whatsapp/markdown.ts
+++ b/src/apps/chatwoot/messages/to/whatsapp/markdown.ts
@@ -4,6 +4,14 @@ export function MarkdownToWhatsApp(text: string): string {
   }
   return (
     text
+      // Normalize escaped newlines: \\\n, \\\\\n, etc. → \n
+      // Fixes issue where ChatWoot sends escaped newlines incorrectly
+      // Matches: two or more backslashes followed by n
+      // Pattern breakdown:
+      //   - (\\\\){1,} matches even numbers: 1+ pairs = 2, 4, 6... backslashes (minimum 2)
+      //   - \\(\\\\)+ matches odd numbers: 1 + 1+ pairs = 3, 5, 7... backslashes (minimum 3)
+      // Together they cover all cases of 2+ backslashes, excluding single \n (legitimate newline)
+      .replace(/((\\\\){1,}|\\(\\\\)+)n/g, '\n')
       // Triple-backtick blocks → WhatsApp monospace blocks (same syntax)
       .replace(/```([\s\S]*?)```/g, '```$1```')
       // Italic **first**, but only single‐star or single‐underscore


### PR DESCRIPTION
In newer versions of ChatWoot, newline characters are being sent incorrectly as escaped sequences (\\\n - backslash, backslash, backslash, n) instead of proper newline characters (\n). This causes messages to display literal backslashes instead of line breaks in WhatsApp.

Solution:
- Added regex normalization at the beginning of MarkdownToWhatsApp transformation chain
- The regex /((\\\\){1,}|\\(\\\\)+)n/g matches escaped newline patterns with 2+ backslashes (both even and odd numbers) and replaces them with proper newlines (\n)
- Pattern breakdown:
  * (\\\\){1,} matches even numbers: 1+ pairs = 2, 4, 6... backslashes (minimum 2)
  * \\(\\\\)+ matches odd numbers: 1 + 1+ pairs = 3, 5, 7... backslashes (minimum 3)
- Together they cover all cases of 2+ backslashes, excluding single \n (legitimate newline)
- Added comprehensive test cases to validate the fix handles:
  * Multiple escaped newlines (3 and 4 backslashes)
  * Even number of backslashes (4 backslashes)
  * Odd number of backslashes (5 backslashes)
  * Single backslash + n (should remain unchanged)

Files changed:
- src/apps/chatwoot/messages/to/whatsapp/markdown.ts
- src/apps/chatwoot/messages/to/whatsapp/markdown.test.ts

Chatwoot Version v4.10.1:
<img width="1368" height="394" alt="WhatsApp Image 2026-01-22 at 10 57 47" src="https://github.com/user-attachments/assets/1cc04c0e-fffb-4858-b89b-9d1cf8b93d00" />

WhatsApp:
<img width="738" height="444" alt="WhatsApp Image 2026-01-22 at 10 57 59" src="https://github.com/user-attachments/assets/e4545ef6-043b-4621-a14b-ee74f85a89fd" />


[![patron:PRO](https://img.shields.io/badge/patron-PRO-188a42)](https://waha.devlike.pro/docs/how-to/plus-version/#tiers)