### PR TITLE
Fix apps GET/PUT/DELETE 403 by adding CheckPolicies guard

### DIFF
--- a/src/apps/app_sdk/api/apps.controller.ts
+++ b/src/apps/app_sdk/api/apps.controller.ts
@@ -22,7 +22,12 @@ import {
 import { SessionManager } from '@waha/core/abc/manager.abc';
 import { CheckPolicies } from '@waha/core/auth/policies.decorator';
 import { PoliciesGuard } from '@waha/core/auth/policies.guard';
-import { CanSession, FromBody, FromQuery } from '@waha/core/auth/policies';
+import {
+  CanServer,
+  CanSession,
+  FromBody,
+  FromQuery,
+} from '@waha/core/auth/policies';
 import { Action, session as SessionName } from '@waha/core/auth/casl.types';
 import { WAHAValidationPipe } from '@waha/nestjs/pipes/WAHAValidationPipe';
 
@@ -65,6 +70,7 @@ export class AppsController {
 
   @Get('/:id')
   @ApiOperation({ summary: 'Get app by ID' })
+  @CheckPolicies(CanServer(Action.Read))
   @UsePipes(new WAHAValidationPipe())
   async get(@Param('id') id: string, @Req() req: any): Promise<App> {
     const app = await this.appsService.get(this.manager, id);
@@ -79,6 +85,7 @@ export class AppsController {
 
   @Put('/:id')
   @ApiOperation({ summary: 'Update an existing app' })
+  @CheckPolicies(CanServer(Action.Read))
   @UsePipes(new WAHAValidationPipe())
   async update(
     @Param('id') id: string,
@@ -114,6 +121,7 @@ export class AppsController {
 
   @Delete('/:id')
   @ApiOperation({ summary: 'Delete an app' })
+  @CheckPolicies(CanServer(Action.Read))
   @UsePipes(new WAHAValidationPipe())
   async delete(@Param('id') id: string, @Req() req: any): Promise<void> {
     const existing = await this.appsService.get(this.manager, id);


### PR DESCRIPTION
Add @CheckPolicies(CanServer(Action.Read)) to GET, PUT, and DELETE /:id endpoints so the PoliciesGuard has an explicit policy instead of throwing when no handler is present. Session name is not available at guard time for these routes, so the guard only enforces server-level read; handlers continue to enforce Action.Use on the app's session via req.ability?.can().





Issue: https://github.com/devlikeapro/waha/issues/1926

[![patron:PRO](https://img.shields.io/badge/patron-PRO-188a42)](https://waha.devlike.pro/docs/how-to/plus-version/#tiers)