### PR TITLE
[core] Fix BR landline normalization in PhoneJidNormalizer

### DIFF
--- a/src/core/utils/PhoneJidNormalizer.test.ts
+++ b/src/core/utils/PhoneJidNormalizer.test.ts
@@ -20,25 +20,18 @@ describe('E164Parser.fromJid', () => {
     expect(E164Parser.fromJid('@s.whatsapp.net')).toBeNull();
   });
 
-  it('applies Brazil add-9 rule when local has 8 digits (any first digit)', () => {
-    // +55 <DDD:2> <local:8>
-    expect(E164Parser.fromJid('553188888888@s.whatsapp.net')).toBe(
-      '+5531988888888',
+  it('does not add 9 for BR landline (local starts with 2..5)', () => {
+    expect(E164Parser.fromJid('558540423147@s.whatsapp.net')).toBe(
+      '+558540423147',
+    );
+    expect(E164Parser.fromJid('558820181896@s.whatsapp.net')).toBe(
+      '+558820181896',
     );
   });
 
-  it('554999111111 => 5549999111111', () => {
-    expect(E164Parser.fromJid('554999111111@s.whatsapp.net')).toBe(
-      '+5549999111111',
-    );
-  });
-
-  it('adds 9 even when local already starts with 9 (Brazil)', () => {
-    expect(E164Parser.fromJid('553198888888@s.whatsapp.net')).toBe(
-      '+5531998888888',
-    );
-    expect(E164Parser.fromJid('553199999999@s.whatsapp.net')).toBe(
-      '+5531999999999',
+  it('adds 9 for BR mobile/others (local not starting with 2..5)', () => {
+    expect(E164Parser.fromJid('558591203123@s.whatsapp.net')).toBe(
+      '+5585991203123',
     );
   });
 

--- a/src/core/utils/PhoneJidNormalizer.ts
+++ b/src/core/utils/PhoneJidNormalizer.ts
@@ -56,7 +56,15 @@ export class PhoneJidNormalizer {
 }
 
 const RULES = [
-  // Brazil - ensure mobile numbers have 9 digits after DDD
+  // Brazil landline (fixed line) heuristic:
+  // +55 <DDD:2> <local:8> where local[0] is 2..5 => do NOT add extra 9
+  {
+    name: 'br-no-add-9-for-landline',
+    re: /^\+55(\d{2})([2-5]\d{7})$/,
+    replace: '+55$1$2',
+  },
+  // Brazil mobile/others:
+  // +55 <DDD:2> <local:8> => add extra 9 after DDD
   {
     name: 'br-add-9-after-ddd',
     re: /^\+55(\d{2})(\d{8})$/,


### PR DESCRIPTION
Correction of BR (landline vs. mobile) normalization in Chatwoot

# Problem
When integrating WAHA with Chatwoot, WAHA populates the contact's phone_number field using a WhatsApp JID normalization for E.164.

Currently, there is a BR rule that always adds the digit "9" when the number is in the format:

+55 + DDD(2) + local(8)
This is incorrect for Brazilian landline numbers, because landlines can also arrive with local(8). Thus, the landline ends up being saved in Chatwoot with an extra "9" after the DDD.

Desired rule
Since there is no perfect universal standard to differentiate between landline and mobile, we apply a heuristic based on the Brazilian standard:

If it's Brazil and the location has 8 digits:

If the location starts with 2 to 5: treat it as a landline and do not add the "9".

Otherwise (including when the location starts with 9): treat it as mobile and add the “9” after the area code.
This preserves what arrives in WhatsApp JID for landline and avoids the unwanted “9” in Chatwoot.

Issue: https://github.com/devlikeapro/waha/issues/1974

[![patron:PRO](https://img.shields.io/badge/patron-PRO-188a42)](https://waha.devlike.pro/docs/how-to/plus-version/#tiers)