### PR TITLE
[core] ChatWoot: conditional agent name prefix in WA to WhatsApp templates

### DIFF
--- a/src/apps/chatwoot/i18n/locales/ar-AE.yaml
+++ b/src/apps/chatwoot/i18n/locales/ar-AE.yaml
@@ -335,12 +335,14 @@ waha.core.version.used: |-
   [**🎁 ادعمنا**]({{{supportUrl}}})
 
 chatwoot.to.whatsapp.message.text: |-
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
 
 chatwoot.to.whatsapp.message.media.caption: |-
   {{#singleAttachment}}
   {{#content}}
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
   {{/content}}
   {{/singleAttachment}}
 

--- a/src/apps/chatwoot/i18n/locales/bn-BD.yaml
+++ b/src/apps/chatwoot/i18n/locales/bn-BD.yaml
@@ -335,12 +335,14 @@ waha.core.version.used: |-
   [**🎁 আমাদের সমর্থন করুন**]({{{supportUrl}}})
 
 chatwoot.to.whatsapp.message.text: |-
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
 
 chatwoot.to.whatsapp.message.media.caption: |-
   {{#singleAttachment}}
   {{#content}}
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
   {{/content}}
   {{/singleAttachment}}
 

--- a/src/apps/chatwoot/i18n/locales/de-DE.yaml
+++ b/src/apps/chatwoot/i18n/locales/de-DE.yaml
@@ -338,12 +338,14 @@ waha.core.version.used: |-
   [**🎁 Unterstützen Sie uns**]({{{supportUrl}}})
 
 chatwoot.to.whatsapp.message.text: |-
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
 
 chatwoot.to.whatsapp.message.media.caption: |-
   {{#singleAttachment}}
   {{#content}}
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
   {{/content}}
   {{/singleAttachment}}
 

--- a/src/apps/chatwoot/i18n/locales/en-US.yaml
+++ b/src/apps/chatwoot/i18n/locales/en-US.yaml
@@ -116,12 +116,14 @@ whatsapp.contact.broadcast.suffix: 'Broadcast List'
 whatsapp.contact.status.name: 'Status'
 
 chatwoot.to.whatsapp.message.text: |-
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
 
 chatwoot.to.whatsapp.message.media.caption: |-
   {{#singleAttachment}}
   {{#content}}
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
   {{/content}}
   {{/singleAttachment}}
 

--- a/src/apps/chatwoot/i18n/locales/es-ES.yaml
+++ b/src/apps/chatwoot/i18n/locales/es-ES.yaml
@@ -335,12 +335,14 @@ waha.core.version.used: |-
   [**🎁 Apóyanos**]({{{supportUrl}}})
 
 chatwoot.to.whatsapp.message.text: |-
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
 
 chatwoot.to.whatsapp.message.media.caption: |-
   {{#singleAttachment}}
   {{#content}}
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
   {{/content}}
   {{/singleAttachment}}
 

--- a/src/apps/chatwoot/i18n/locales/fa-IR.yaml
+++ b/src/apps/chatwoot/i18n/locales/fa-IR.yaml
@@ -335,12 +335,14 @@ waha.core.version.used: |-
   [**🎁 از ما حمایت کنید**]({{{supportUrl}}})
 
 chatwoot.to.whatsapp.message.text: |-
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
 
 chatwoot.to.whatsapp.message.media.caption: |-
   {{#singleAttachment}}
   {{#content}}
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
   {{/content}}
   {{/singleAttachment}}
 

--- a/src/apps/chatwoot/i18n/locales/fr-FR.yaml
+++ b/src/apps/chatwoot/i18n/locales/fr-FR.yaml
@@ -335,12 +335,14 @@ waha.core.version.used: |-
   [**🎁 Soutenez-nous**]({{{supportUrl}}})
 
 chatwoot.to.whatsapp.message.text: |-
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
 
 chatwoot.to.whatsapp.message.media.caption: |-
   {{#singleAttachment}}
   {{#content}}
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
   {{/content}}
   {{/singleAttachment}}
 

--- a/src/apps/chatwoot/i18n/locales/he-IL.yaml
+++ b/src/apps/chatwoot/i18n/locales/he-IL.yaml
@@ -335,12 +335,14 @@ waha.core.version.used: |-
   [**🎁 תמוך בנו**]({{{supportUrl}}})
 
 chatwoot.to.whatsapp.message.text: |-
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
 
 chatwoot.to.whatsapp.message.media.caption: |-
   {{#singleAttachment}}
   {{#content}}
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
   {{/content}}
   {{/singleAttachment}}
 

--- a/src/apps/chatwoot/i18n/locales/hi-IN.yaml
+++ b/src/apps/chatwoot/i18n/locales/hi-IN.yaml
@@ -335,12 +335,14 @@ waha.core.version.used: |-
   [**🎁 हमें समर्थन दें**]({{{supportUrl}}})
 
 chatwoot.to.whatsapp.message.text: |-
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
 
 chatwoot.to.whatsapp.message.media.caption: |-
   {{#singleAttachment}}
   {{#content}}
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
   {{/content}}
   {{/singleAttachment}}
 

--- a/src/apps/chatwoot/i18n/locales/id-ID.yaml
+++ b/src/apps/chatwoot/i18n/locales/id-ID.yaml
@@ -335,12 +335,14 @@ waha.core.version.used: |-
   [**🎁 Dukung Kami**]({{{supportUrl}}})
 
 chatwoot.to.whatsapp.message.text: |-
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
 
 chatwoot.to.whatsapp.message.media.caption: |-
   {{#singleAttachment}}
   {{#content}}
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
   {{/content}}
   {{/singleAttachment}}
 

--- a/src/apps/chatwoot/i18n/locales/it-IT.yaml
+++ b/src/apps/chatwoot/i18n/locales/it-IT.yaml
@@ -116,12 +116,14 @@ whatsapp.contact.broadcast.suffix: 'Lista Broadcast'
 whatsapp.contact.status.name: 'Stato'
 
 chatwoot.to.whatsapp.message.text: |-
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
 
 chatwoot.to.whatsapp.message.media.caption: |-
   {{#singleAttachment}}
   {{#content}}
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
   {{/content}}
   {{/singleAttachment}}
 

--- a/src/apps/chatwoot/i18n/locales/pa-PK.yaml
+++ b/src/apps/chatwoot/i18n/locales/pa-PK.yaml
@@ -335,12 +335,14 @@ waha.core.version.used: |-
   [**🎁 ਸਾਡਾ ਸਮਰਥਨ ਕਰੋ**]({{{supportUrl}}})
 
 chatwoot.to.whatsapp.message.text: |-
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
 
 chatwoot.to.whatsapp.message.media.caption: |-
   {{#singleAttachment}}
   {{#content}}
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
   {{/content}}
   {{/singleAttachment}}
 

--- a/src/apps/chatwoot/i18n/locales/pt-BR.yaml
+++ b/src/apps/chatwoot/i18n/locales/pt-BR.yaml
@@ -336,12 +336,14 @@ waha.core.version.used: |-
   [**🎁 Apoie-nos**]({{{supportUrl}}})
 
 chatwoot.to.whatsapp.message.text: |-
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
 
 chatwoot.to.whatsapp.message.media.caption: |-
   {{#singleAttachment}}
   {{#content}}
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
   {{/content}}
   {{/singleAttachment}}
 

--- a/src/apps/chatwoot/i18n/locales/ru-RU.yaml
+++ b/src/apps/chatwoot/i18n/locales/ru-RU.yaml
@@ -335,12 +335,14 @@ waha.core.version.used: |-
   [**🎁 Поддержать нас**]({{{supportUrl}}})
 
 chatwoot.to.whatsapp.message.text: |-
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
 
 chatwoot.to.whatsapp.message.media.caption: |-
   {{#singleAttachment}}
   {{#content}}
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
   {{/content}}
   {{/singleAttachment}}
 

--- a/src/apps/chatwoot/i18n/locales/tr-TR.yaml
+++ b/src/apps/chatwoot/i18n/locales/tr-TR.yaml
@@ -335,12 +335,14 @@ waha.core.version.used: |-
   [**🎁 Bizi Destekleyin**]({{{supportUrl}}})
 
 chatwoot.to.whatsapp.message.text: |-
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
 
 chatwoot.to.whatsapp.message.media.caption: |-
   {{#singleAttachment}}
   {{#content}}
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
   {{/content}}
   {{/singleAttachment}}
 

--- a/src/apps/chatwoot/i18n/locales/uk-UA.yaml
+++ b/src/apps/chatwoot/i18n/locales/uk-UA.yaml
@@ -335,12 +335,14 @@ waha.core.version.used: |-
   [**🎁 Підтримайте нас**]({{{supportUrl}}})
 
 chatwoot.to.whatsapp.message.text: |-
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
 
 chatwoot.to.whatsapp.message.media.caption: |-
   {{#singleAttachment}}
   {{#content}}
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
   {{/content}}
   {{/singleAttachment}}
 

--- a/src/apps/chatwoot/i18n/locales/ur-PK.yaml
+++ b/src/apps/chatwoot/i18n/locales/ur-PK.yaml
@@ -335,12 +335,14 @@ waha.core.version.used: |-
   [**🎁 ہماری حمایت کریں**]({{{supportUrl}}})
 
 chatwoot.to.whatsapp.message.text: |-
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
 
 chatwoot.to.whatsapp.message.media.caption: |-
   {{#singleAttachment}}
   {{#content}}
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
   {{/content}}
   {{/singleAttachment}}
 

--- a/src/apps/chatwoot/i18n/locales/zh-CN.yaml
+++ b/src/apps/chatwoot/i18n/locales/zh-CN.yaml
@@ -335,12 +335,14 @@ waha.core.version.used: |-
   [**🎁 支持我们**]({{{supportUrl}}})
 
 chatwoot.to.whatsapp.message.text: |-
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
 
 chatwoot.to.whatsapp.message.media.caption: |-
   {{#singleAttachment}}
   {{#content}}
-  {{{ content }}}
+  {{#chatwoot.sender.name}}*{{{chatwoot.sender.name}}}*:
+  {{/chatwoot.sender.name}}{{{ content }}}
   {{/content}}
   {{/singleAttachment}}
 


### PR DESCRIPTION


Fix empty **: prefix when Add Agent Name is on but chatwoot.sender.name is empty (e.g. system/automated messages). Applies Mustache conditionals to default i18n for chatwoot.to.whatsapp.message.text and chatwoot.to.whatsapp.message.media.caption across all locales. 
fixes devlikeapro/waha#1983
fixes devlikeapro/waha#1737

[![patron:PRO](https://img.shields.io/badge/patron-PRO-188a42)](https://waha.devlike.pro/docs/how-to/plus-version/#tiers)