### PR TITLE
[core] Fix restartStoppedSessions aborting on one stuck session

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -179,7 +179,7 @@ RUN if [ "$USE_BROWSER" = "chromium" ]; then \
 # Install Chrome
 # Available versions:
 # https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-ARG CHROME_VERSION="140.0.7339.80-1"
+ARG CHROME_VERSION="140.0.7339.207-1"
 ARG OPUSTAGS_VERSION="1.10.1"
 RUN if [ "$USE_BROWSER" = "chrome" ]; then \
         wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb \

--- a/src/core/manager.core.ts
+++ b/src/core/manager.core.ts
@@ -21,6 +21,7 @@ import { getProxyConfig } from '@waha/core/helpers.proxy';
 import { WebhookConductor } from '@waha/core/integrations/webhooks/WebhookConductor';
 import { MediaManager } from '@waha/core/media/MediaManager';
 import { MediaStorageFactory } from '@waha/core/media/MediaStorageFactory';
+import { restartStoppedSessionsLoop } from '@waha/core/utils/restartSessions';
 import { LocalSessionAuthRepository } from '@waha/core/storage/LocalSessionAuthRepository';
 import { LocalSessionConfigRepository } from '@waha/core/storage/LocalSessionConfigRepository';
 import { LocalStoreCore } from '@waha/core/storage/LocalStoreCore';
@@ -234,17 +235,13 @@ export class SessionManagerCore
     const sleepS = this.config.autoStartDelaySeconds;
     this.log.info(`Restarting sessions with delay of ${sleepS} seconds...`);
     const sleepMs = this.config.autoStartDelaySeconds * 1000;
-    for (const sessionName of sessions) {
-      await this.withLock(sessionName, async () => {
-        const log = this.log.logger.child({ session: sessionName });
-        log.info(`Restarting STOPPED session...`);
-        await this.start(sessionName).catch((error) => {
-          log.error(`Failed to start STOPPED session: ${error}`);
-          log.error(error.stack);
-        });
-      });
-      await sleep(sleepMs);
-    }
+    await restartStoppedSessionsLoop({
+      sessions: sessions,
+      sleepMs: sleepMs,
+      withLock: (name, fn) => this.withLock(name, fn),
+      start: (name) => this.start(name),
+      loggerFor: (name) => this.log.logger.child({ session: name }),
+    });
     this.log.info(`STOPPED sessions have been restarted.`);
   }
 

--- a/src/core/utils/restartSessions.test.ts
+++ b/src/core/utils/restartSessions.test.ts
@@ -1,0 +1,69 @@
+import { restartStoppedSessionsLoop } from '@waha/core/utils/restartSessions';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const AsyncLock = require('async-lock');
+
+/**
+ * Regression test: a single STOPPED session that takes longer than the lock's
+ * maxExecutionTime to start used to abort restartStoppedSessions() entirely,
+ * so every session after it in the list never got restarted.
+ */
+
+function buildLock() {
+  // Same options as SessionManager in manager.abc.ts, just a faster ceiling.
+  return new AsyncLock({
+    timeout: 5_000,
+    maxPending: Infinity,
+    maxExecutionTime: 50, // production uses 30_000
+  });
+}
+
+describe('restartStoppedSessionsLoop', () => {
+  it('restarts every session even when one exceeds the lock max execution time', async () => {
+    const lock = buildLock();
+    const started: string[] = [];
+    const errors: string[] = [];
+
+    await restartStoppedSessionsLoop({
+      sessions: ['alpha', 'regional', 'beta', 'gamma'],
+      sleepMs: 0,
+      withLock: (name, fn) => lock.acquire(name, fn),
+      start: async (name: string) => {
+        if (name === 'regional') {
+          // Simulates a session stuck reconnecting after being disconnected
+          // for a long time - never settles, same as the real-world report.
+          await new Promise(() => undefined);
+        }
+        started.push(name);
+      },
+      loggerFor: () => ({
+        info: () => undefined,
+        error: (msg: string) => errors.push(msg),
+      }),
+    });
+
+    expect(started).toEqual(['alpha', 'beta', 'gamma']);
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('Maximum execution time is exceeded'),
+      ]),
+    );
+  });
+
+  it('restarts all sessions normally when none get stuck', async () => {
+    const lock = buildLock();
+    const started: string[] = [];
+
+    await restartStoppedSessionsLoop({
+      sessions: ['alpha', 'beta', 'gamma'],
+      sleepMs: 0,
+      withLock: (name, fn) => lock.acquire(name, fn),
+      start: async (name: string) => {
+        started.push(name);
+      },
+      loggerFor: () => ({ info: () => undefined, error: () => undefined }),
+    });
+
+    expect(started).toEqual(['alpha', 'beta', 'gamma']);
+  });
+});

--- a/src/core/utils/restartSessions.ts
+++ b/src/core/utils/restartSessions.ts
@@ -1,0 +1,40 @@
+import { sleep } from '@waha/utils/promiseTimeout';
+import { Logger } from 'pino';
+
+interface RestartStoppedSessionsOptions {
+  sessions: string[];
+  withLock: (name: string, fn: () => any) => Promise<any>;
+  start: (name: string) => Promise<unknown>;
+  loggerFor: (name: string) => Pick<Logger, 'info' | 'error'>;
+  sleepMs: number;
+}
+
+/**
+ * Restarts STOPPED sessions one by one, with a delay in between.
+ *
+ * Lives outside manager.core.ts so it can be unit tested - importing
+ * manager.core.ts pulls in every engine (and baileys, which Jest can't parse).
+ */
+export async function restartStoppedSessionsLoop(
+  options: RestartStoppedSessionsOptions,
+): Promise<void> {
+  const { sessions, withLock, start, loggerFor, sleepMs } = options;
+  for (const sessionName of sessions) {
+    const log = loggerFor(sessionName);
+    // A single session stuck past the lock's maxExecutionTime rejects
+    // withLock() itself (not caught by start()'s own .catch() below), which
+    // would otherwise bubble up and abort this loop - skipping every
+    // session after it. Catch it here so one bad session can't block the rest.
+    await withLock(sessionName, async () => {
+      log.info(`Restarting STOPPED session...`);
+      await start(sessionName).catch((error) => {
+        log.error(`Failed to start STOPPED session: ${error}`);
+        log.error(error.stack);
+      });
+    }).catch((error) => {
+      log.error(`Failed to restart STOPPED session: ${error}`);
+      log.error(error.stack);
+    });
+    await sleep(sleepMs);
+  }
+}

--- a/waha.config.json
+++ b/waha.config.json
@@ -2,7 +2,7 @@
   "waha": {
     "gows": {
       "repo": "devlikeapro/gows-plus",
-      "ref": "v1.0.43"
+      "ref": "v1.0.44"
     },
     "dashboard": {
       "repo": "devlikeapro/dashboard",


### PR DESCRIPTION
withLock()'s lock.acquire() rejects with its own 'Maximum execution time is exceeded' error when a session takes longer than maxExecutionTime (30s) to start - a rejection start()'s own .catch() never sees, since it comes from the lock wrapper, not start() itself. Uncaught, it propagated out of the for loop in
restartStoppedSessions() and aborted restarting every session that came after the stuck one.

Reported from production: a session disconnected for a long time hung past the lock ceiling on container start, and every STOPPED session listed after it in sessionConfigRepository.getAllConfigs() never got restarted.

The loop lives in restartSessions.ts so it can be unit tested - importing manager.core.ts pulls in every engine, including baileys, which Jest can't parse ("Cannot use import statement outside a module"). The test exercises the same function that runs in production: reverting the .catch() makes it fail.

[![patron:PRO](https://img.shields.io/badge/patron-PRO-188a42)](https://waha.devlike.pro/docs/how-to/plus-version/#tiers)