### PR TITLE
fix(core): internal self-calls fail when HTTP server binds to IPv6 only

### DIFF
--- a/src/apps/app_sdk/waha/WAHASelf.ts
+++ b/src/apps/app_sdk/waha/WAHASelf.ts
@@ -29,7 +29,11 @@ export class WAHASelf {
       parseInt(process.env.PORT) ||
       parseInt(process.env.WHATSAPP_API_PORT) ||
       3000;
-    const url = `http://localhost:${port}`;
+    // Use 127.0.0.1 (IPv4 loopback) instead of "localhost" to avoid
+    // resolution ambiguity. WAHA forces IPv4 via undici dispatcher, and
+    // some platforms bind the HTTP server to IPv6 only ("::1"), so a
+    // bare "localhost" can resolve to 127.0.0.1 and fail to connect.
+    const url = `http://127.0.0.1:${port}`;
     this.client = axios.create({
       baseURL: url,
       headers: {

--- a/src/apps/chatwoot/contacts/WhatsAppContactInfo.ts
+++ b/src/apps/chatwoot/contacts/WhatsAppContactInfo.ts
@@ -98,6 +98,7 @@ class LidContactInfo extends ChatContactInfo {
     return new JidContactInfo(this.session, pn, this.locale);
   }
 
+  @CacheAsync()
   async AvatarUrl(): Promise<string | null> {
     const jid = await this.jid();
     if (jid) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -101,7 +101,11 @@ async function bootstrap() {
   AppModule.appReady(app, logger);
   app.enableShutdownHooks();
   const config = app.get(WhatsappConfigService);
-  await app.listen(config.port);
+  // Bind explicitly to 0.0.0.0 so the HTTP server accepts IPv4 traffic.
+  // When host is omitted, Node may bind to "::1" (IPv6 loopback) on some
+  // platforms, which makes internal axios calls to "http://localhost:3000"
+  // fail to connect (localhost resolves to 127.0.0.1 and IPv4 is refused).
+  await app.listen(config.port, '0.0.0.0');
   logger.info(`WhatsApp HTTP API is running on: ${await app.getUrl()}`);
   logger.info(VERSION, 'Environment');
 }


### PR DESCRIPTION
## Summary

Fix internal self-calls failing silently when the HTTP server binds to IPv6 loopback only (`[::1]`), which causes `ChatWootAppService` to never set the contact avatar in ChatWoot.

### Root cause

`src/main.ts` calls `app.listen(config.port)` without an explicit host. On some Docker / Node 22 setups, the resulting HTTP server only binds to `[::1]:3000` (IPv6 loopback). The startup log confirms it:

```
WhatsApp HTTP API is running on: http://[::1]:3000
```

At the same time, `setGlobalDispatcher(new Agent({ connect: { family: 4 } }))` (same file, line 39) forces the global undici HTTP client (used internally by axios) to IPv4 only.

The internal client used for self-calls (`WAHASelf`) is created with:

```ts
const url = `http://localhost:${port}`;
```

When `localhost` resolves to `127.0.0.1` (the default for IPv4-first lookups), the TCP connect is refused because nothing is listening on `127.0.0.1:3000` — only on `[::1]:3000`. The error is swallowed upstream (no logger, no `catch` in `WAHASelf.getChatPicture`), so callers silently get `null`.

The visible symptom is `ContactService.updateAvatar` receiving `null` for `AvatarUrl()`, leaving every ChatWoot contact without a profile picture. The ChatWoot-side webhook still works (it's an inbound request), so the issue is easy to miss.

### Repro

1. Start WAHA on a host where Node 22 picks `[::1]` for the default listen (some Docker / Linux IPv6 setups do this).
2. Connect a WhatsApp session.
3. Have ChatWoot app enabled.
4. Send a message from a contact → `WAHAMessageAnyConsumer` creates the contact, calls `updateAvatar`, which calls `getChatPicture` internally. The internal axios call to `http://localhost:3000/api/{session}/chats/{chatId}/picture` hangs/fails silently and returns `null`. The contact is created in ChatWoot without an avatar.
5. Direct external calls to the same endpoint (via the public URL with `WAHA_BASE_URL`) succeed — only the self-call path is broken, which is why it looks like the API works fine.

### Fix

1. **Bind explicitly to `0.0.0.0`** (`src/main.ts`) so the HTTP server accepts IPv4 traffic in addition to IPv6. Removes the platform-dependent behavior of `app.listen(port)`.

2. **Use `127.0.0.1` instead of `localhost`** in `WAHASelf` (`src/apps/app_sdk/waha/WAHASelf.ts`). Eliminates DNS resolution ambiguity for the internal self-call base URL. `localhost` can resolve to `::1` on systems with `ipv6` enabled and `files /etc/hosts` entries, which would also break even after fixing #1 on some platforms.

3. **Add `@CacheAsync()` to `LidContactInfo.AvatarUrl`** (`src/apps/chatwoot/contacts/WhatsAppContactInfo.ts`). `JidContactInfo.AvatarUrl` and every other implementation already have this decorator; `LidContactInfo` was missing it, so every avatar resolution made a fresh HTTP call (and a fresh LID→PN resolution + nested avatar lookup).

### Tested in production

WAHA Plus 2026.7.1, WEBJS engine, ChatWoot app, behind a reverse proxy:

| Scenario | Before | After |
|---|---|---|
| Contact created from incoming WhatsApp message | No avatar (ChatWoot `thumbnail` empty) | Avatar present (ChatWoot pulls `pps.whatsapp.net` URL from `avatar_url`) |
| Direct GET `/api/{session}/chats/{chatId}/picture` (public URL) | 200 with `pps.whatsapp.net` URL | 200 with `pps.whatsapp.net` URL (unchanged) |
| Internal `WAHASelf.getChatPicture(...)` | Fails silently → returns `null` | 200 with `pps.whatsapp.net` URL |
| Container startup log | `running on: http://[::1]:3000` | `running on: http://0.0.0.0:3000` |

The patched build has been running in production since the fix was applied with no regressions.

### Files changed

- `src/main.ts` — `app.listen(config.port, '0.0.0.0')`
- `src/apps/app_sdk/waha/WAHASelf.ts` — base URL `127.0.0.1`
- `src/apps/chatwoot/contacts/WhatsAppContactInfo.ts` — `@CacheAsync()` on `LidContactInfo.AvatarUrl`

### Out of scope (intentionally not changed)

- The `setGlobalDispatcher(... family: 4)` global in `src/main.ts:39` is left as-is. It only affects outgoing HTTP from Node, not the listen bind. Removing it would change a wider surface (S3, MongoDB, webhook delivery, etc.) and needs a separate discussion.
- The `LidContactInfo.Attributes()` and other methods are already cached.