### PR TITLE
[core] feat(NOWEB): expose group member-add-mode as a settable endpoint

### DIFF
--- a/src/api/groups.controller.ts
+++ b/src/api/groups.controller.ts
@@ -38,6 +38,7 @@ import {
   JoinGroupRequest,
   JoinGroupResponse,
   ParticipantsRequest,
+  SettingsMemberAddMode,
   SettingsSecurityChangeInfo,
   SubjectRequest,
 } from '../structures/groups.dto';
@@ -307,6 +308,39 @@ export class GroupsController {
     @Param('id') id: string,
   ): Promise<SettingsSecurityChangeInfo> {
     return session.getMessagesAdminsOnly(id);
+  }
+
+  @Put(':id/settings/security/member-add-mode')
+  @SessionApiParam
+  @GroupIdApiParam
+  @CheckPolicies(CanSession(Action.Send, FromParam('session')))
+  @ApiOperation({
+    summary: 'Update settings - who can add new members',
+    description:
+      'Updates the group settings for who can add new members to the group - all members or admins only.',
+  })
+  setMemberAddMode(
+    @WorkingSessionParam session: WhatsappSession,
+    @Param('id') id: string,
+    @Body() request: SettingsMemberAddMode,
+  ) {
+    return session.setMemberAddMode(id, request.membersCanAddNewMember);
+  }
+
+  @Get(':id/settings/security/member-add-mode')
+  @SessionApiParam
+  @GroupIdApiParam
+  @CheckPolicies(CanSession(Action.Read, FromParam('session')))
+  @ApiOperation({
+    summary: 'Get settings - who can add new members',
+    description:
+      'The group settings for who can add new members to the group - all members or admins only.',
+  })
+  getMemberAddMode(
+    @WorkingSessionParam session: WhatsappSession,
+    @Param('id') id: string,
+  ): Promise<SettingsMemberAddMode> {
+    return session.getMemberAddMode(id);
   }
 
   @Get(':id/invite-code')

--- a/src/core/abc/session.abc.ts
+++ b/src/core/abc/session.abc.ts
@@ -107,6 +107,7 @@ import {
   GroupParticipant,
   GroupsListFields,
   ParticipantsRequest,
+  SettingsMemberAddMode,
   SettingsSecurityChangeInfo,
 } from '../../structures/groups.dto';
 import { WAHAChatPresences } from '../../structures/presence.dto';
@@ -1002,6 +1003,14 @@ export abstract class WhatsappSession {
   }
 
   public setMessagesAdminsOnly(id, value) {
+    throw new NotImplementedByEngineError();
+  }
+
+  public getMemberAddMode(id): Promise<SettingsMemberAddMode> {
+    throw new NotImplementedByEngineError();
+  }
+
+  public setMemberAddMode(id, value) {
     throw new NotImplementedByEngineError();
   }
 

--- a/src/core/engines/noweb/session.noweb.core.ts
+++ b/src/core/engines/noweb/session.noweb.core.ts
@@ -149,6 +149,7 @@ import {
   CreateGroupRequest,
   GroupParticipant,
   ParticipantsRequest,
+  SettingsMemberAddMode,
   SettingsSecurityChangeInfo,
 } from '@waha/structures/groups.dto';
 import {
@@ -1934,6 +1935,17 @@ export class WhatsappSessionNoWebCore extends WhatsappSession {
   public async setMessagesAdminsOnly(id, value) {
     const setting = value ? 'announcement' : 'not_announcement';
     return await this.sock.groupSettingUpdate(id, setting);
+  }
+
+  public async getMemberAddMode(id): Promise<SettingsMemberAddMode> {
+    const group = await this.getGroup(id);
+    return { membersCanAddNewMember: group.memberAddMode };
+  }
+
+  @Activity()
+  public async setMemberAddMode(id, value) {
+    const mode = value ? 'all_member_add' : 'admin_add';
+    return await this.sock.groupMemberAddMode(id, mode);
   }
 
   @Activity()

--- a/src/structures/groups.dto.ts
+++ b/src/structures/groups.dto.ts
@@ -26,6 +26,10 @@ export class SettingsSecurityChangeInfo {
   adminsOnly: boolean = true;
 }
 
+export class SettingsMemberAddMode {
+  membersCanAddNewMember: boolean = true;
+}
+
 /**
  * Queries
  */


### PR DESCRIPTION
Implements #2165.

The underlying capability already exists in the bundled baileys fork (`groupMemberAddMode`), and the read side is already surfaced on the `Group` model as `membersCanAddNewMember` — but there is no way to *set* it, so a group's add-permission can currently only be changed from a phone.

## What this adds

```
GET  /api/:session/groups/:id/settings/security/member-add-mode
PUT  /api/:session/groups/:id/settings/security/member-add-mode
```

- **GET** returns `{ membersCanAddNewMember: boolean }`
- **PUT** accepts `{ membersCanAddNewMember: boolean }`, mapping `true -> 'all_member_add'`, `false -> 'admin_add'`

## Design notes

I tried to follow the existing conventions rather than invent new ones:

- **Mirrors the sibling routes.** Structured after `settings/security/info-admin-only` and `messages-admin-only`.
- **Reuses your existing mapping.** The getter returns `group.memberAddMode` into `membersCanAddNewMember` — the identical expression already used in `src/core/engines/noweb/groups.noweb.ts:34`.
- **NOWEB-only.** The abstract base throws `NotImplementedByEngineError`, consistent with other engine-specific group settings.
- **`@Activity()` on the setter, not the getter**, matching `getInfoAdminsOnly` / `setInfoAdminsOnly`.
- **Naming.** Uses `membersCanAddNewMember` rather than the inverted `adminsOnly` style of the siblings, so request/response shapes match what the `Group` model already reports. Happy to switch to `adminsOnly` semantics if you would rather the settings endpoints stay internally consistent with each other — say the word.

Touches `src/api`, `src/core`, `src/structures` only. No `src/plus`, hence the `[core]` prefix.

## Testing status — please read

Honest scope of verification: this is **route-verified on a build**, not proven in production. It was authored against `2026.5.1`, built, and the endpoints confirmed reachable and correctly shaped. The deployment it was written for was subsequently cancelled on our side, so it has **not** run against a live WhatsApp session over time.

The NOWEB implementation is a single `this.sock.groupMemberAddMode(id, mode)` call verified against the pinned baileys fork, so the surface area is small — but I would rather state the limit plainly than imply field-tested.

Applies cleanly to current `core` (`2026.7.1`) with no conflicts.
