### PR TITLE
 [core] feat(GOWS): expose new-chat message capping (per-cycle quota)

### DIFF
--- a/src/api/sessions.controller.ts
+++ b/src/api/sessions.controller.ts
@@ -34,6 +34,7 @@ import { WhatsappSession } from '../core/abc/session.abc';
 import {
   ListSessionsQuery,
   MeInfo,
+  MessageCappingData,
   SessionCreateRequest,
   SessionDTO,
   SessionExpand,
@@ -96,6 +97,23 @@ class SessionsController {
   @CheckPolicies(CanSession(Action.Read, FromParam('session')))
   getMe(@SessionParam session: WhatsappSession): MeInfo | null {
     return this.sessionService.getSessionMe(session);
+  }
+
+  @Get(':session/capping')
+  @SessionApiParam
+  @ApiOperation({
+    summary: 'Fetch the account new-chat message capping (per-cycle quota)',
+    description:
+      'Fetch a fresh new-chat message capping (quota) state from WhatsApp. ' +
+      'The same value is also available under me.messageCapping in the session ' +
+      'info, and changes are pushed through the session.status event. ' +
+      'GOWS engine only.',
+  })
+  @CheckPolicies(CanSession(Action.Read, FromParam('session')))
+  fetchMessageCapping(
+    @SessionParam session: WhatsappSession,
+  ): Promise<MessageCappingData> {
+    return session.fetchMessageCapping();
   }
 
   @Post('')

--- a/src/apps/mcp/tools/sessions.tools.ts
+++ b/src/apps/mcp/tools/sessions.tools.ts
@@ -171,4 +171,23 @@ export class SessionTools extends McpController {
       url: `/api/sessions/${session}/restart`,
     });
   }
+
+  @Tool('sessions-capping', {
+    title: 'Get message capping',
+    description:
+      'Fetch the account new-chat message capping (per-cycle quota). ' +
+      'GOWS engine only.',
+    inputSchema: SessionNameInput,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+    },
+  })
+  async capping({ session }: z.infer<typeof SessionNameInput>) {
+    return this.textRequest({
+      method: 'GET',
+      url: `/api/sessions/${session}/capping`,
+    });
+  }
 }

--- a/src/core/abc/MessageCappingTracker.ts
+++ b/src/core/abc/MessageCappingTracker.ts
@@ -1,0 +1,39 @@
+import { MessageCappingData } from '@waha/structures/sessions.dto';
+import * as lodash from 'lodash';
+import { Logger } from 'pino';
+import { Observable, Subject } from 'rxjs';
+
+/**
+ * WhatsApp new-chat message capping (per-cycle quota).
+ * The volume counterpart of the reachout timelock: it caps how many new chats
+ * the account may start per cycle. Keeps the latest known state and emits
+ * changes. Unlike the timelock there is no client-side expiry - the cycle
+ * resets on the server and the state is refreshed by re-fetching.
+ */
+export class MessageCappingTracker {
+  private capping: MessageCappingData | null = null;
+  private changes: Subject<MessageCappingData | null> = new Subject();
+
+  constructor(private logger: Logger) {}
+
+  get value(): MessageCappingData | null {
+    return this.capping;
+  }
+
+  get changes$(): Observable<MessageCappingData | null> {
+    return this.changes;
+  }
+
+  update(capping: MessageCappingData | null) {
+    if (lodash.isEqual(this.capping, capping)) {
+      return;
+    }
+    this.apply(capping);
+  }
+
+  private apply(capping: MessageCappingData | null) {
+    this.capping = capping;
+    this.logger.info({ messageCapping: capping }, 'Message capping updated');
+    this.changes.next(capping);
+  }
+}

--- a/src/core/abc/session.abc.ts
+++ b/src/core/abc/session.abc.ts
@@ -1,3 +1,4 @@
+import { MessageCappingTracker } from '@waha/core/abc/MessageCappingTracker';
 import { ReachoutTimelockTracker } from '@waha/core/abc/ReachoutTimelockTracker';
 import { getBrowserExecutablePath as getBrowserExecutablePathAutodetect } from '@waha/core/abc/session.browser';
 import { IMediaConverter } from '@waha/core/media/IConverter';
@@ -114,6 +115,8 @@ import {
 import { WAHAChatPresences } from '../../structures/presence.dto';
 import {
   MeInfo,
+  MessageCappingData,
+  MessageCappingStatus,
   ProxyConfig,
   SessionConfig,
 } from '../../structures/sessions.dto';
@@ -199,6 +202,7 @@ export abstract class WhatsappSession {
   private _status: WAHASessionStatus;
   private _statusData: any = null;
   protected reachoutTimelock: ReachoutTimelockTracker;
+  protected messageCapping: MessageCappingTracker;
   private _presence:
     | WAHAPresenceStatus.ONLINE
     | WAHAPresenceStatus.OFFLINE
@@ -251,6 +255,15 @@ export abstract class WhatsappSession {
         // Re-issue WORKING so 'session.status' consumers get the update
         this.setStatus(WAHASessionStatus.WORKING, {
           reachoutTimelock: timelock,
+        });
+      }
+    });
+    this.messageCapping = new MessageCappingTracker(this.logger);
+    this.messageCapping.changes$.subscribe((capping) => {
+      if (this.status === WAHASessionStatus.WORKING) {
+        // Re-issue WORKING so 'session.status' consumers get the update
+        this.setStatus(WAHASessionStatus.WORKING, {
+          messageCapping: capping,
         });
       }
     });
@@ -362,13 +375,20 @@ export abstract class WhatsappSession {
       // wait for STOPPED event, ignore the rest
       return;
     }
-    if (
-      status === WAHASessionStatus.WORKING &&
-      data == null &&
-      this.reachoutTimelock.value?.isActive
-    ) {
-      // Plain 'status = WORKING' assignments (reconnects) must keep carrying the active timelock info
-      data = { reachoutTimelock: this.reachoutTimelock.value };
+    if (status === WAHASessionStatus.WORKING && data == null) {
+      // Plain 'status = WORKING' assignments (reconnects) must keep carrying the
+      // active account-restriction info so 'session.status' consumers do not lose it
+      const carry: any = {};
+      if (this.reachoutTimelock.value?.isActive) {
+        carry.reachoutTimelock = this.reachoutTimelock.value;
+      }
+      const capping = this.messageCapping.value;
+      if (capping && capping.cappingStatus !== MessageCappingStatus.NONE) {
+        carry.messageCapping = capping;
+      }
+      if (Object.keys(carry).length > 0) {
+        data = carry;
+      }
     }
     if (
       status === WAHASessionStatus.STOPPED ||
@@ -503,6 +523,10 @@ export abstract class WhatsappSession {
    */
 
   public browserTrace(query: BrowserTraceQuery): Promise<string> {
+    throw new NotImplementedByEngineError();
+  }
+
+  public fetchMessageCapping(): Promise<MessageCappingData> {
     throw new NotImplementedByEngineError();
   }
 

--- a/src/core/engines/gows/capping.ts
+++ b/src/core/engines/gows/capping.ts
@@ -1,0 +1,32 @@
+import {
+  MessageCappingData,
+  MessageCappingStatus,
+} from '@waha/structures/sessions.dto';
+import { EnsureSeconds } from '@waha/utils/timehelper';
+
+function parseCappingTimestamp(value: any): number | null {
+  if (!value) {
+    return null;
+  }
+  const parsed = parseInt(value, 10);
+  return Number.isNaN(parsed) ? null : EnsureSeconds(parsed);
+}
+
+/**
+ * Normalize gows' MessageCapping payload (xwa2_message_capping_info).
+ */
+export function parseGowsMessageCapping(data: any): MessageCappingData {
+  const cappingStatus = (data?.capping_status ??
+    MessageCappingStatus.NONE) as MessageCappingStatus;
+  return {
+    cappingStatus: cappingStatus,
+    // total/used quota are Go ints, so numbers here; -1 total means "no cap"
+    totalQuota: typeof data?.total_quota === 'number' ? data.total_quota : -1,
+    usedQuota: typeof data?.used_quota === 'number' ? data.used_quota : 0,
+    // cycle timestamps are unix seconds strings, absent when zero (Go's omitzero)
+    cycleStart: parseCappingTimestamp(data?.cycle_start_timestamp),
+    cycleEnd: parseCappingTimestamp(data?.cycle_end_timestamp),
+    mvStatus: data?.mv_status ?? null,
+    oteStatus: data?.ote_status ?? null,
+  };
+}

--- a/src/core/engines/gows/grpc/gows.ts
+++ b/src/core/engines/gows/grpc/gows.ts
@@ -11434,6 +11434,15 @@ export namespace messages {
                 responseSerialize: (message: Empty) => Buffer.from(message.serialize()),
                 responseDeserialize: (bytes: Buffer) => Empty.deserialize(new Uint8Array(bytes))
             },
+            FetchMessageCapping: {
+                path: "/messages.MessageService/FetchMessageCapping",
+                requestStream: false,
+                responseStream: false,
+                requestSerialize: (message: Session) => Buffer.from(message.serialize()),
+                requestDeserialize: (bytes: Buffer) => Session.deserialize(new Uint8Array(bytes)),
+                responseSerialize: (message: Json) => Buffer.from(message.serialize()),
+                responseDeserialize: (bytes: Buffer) => Json.deserialize(new Uint8Array(bytes))
+            },
             GenerateNewMessageID: {
                 path: "/messages.MessageService/GenerateNewMessageID",
                 requestStream: false,
@@ -11751,6 +11760,7 @@ export namespace messages {
         abstract SubscribePresence(call: grpc_1.ServerUnaryCall<SubscribePresenceRequest, Empty>, callback: grpc_1.sendUnaryData<Empty>): void;
         abstract CheckPhones(call: grpc_1.ServerUnaryCall<CheckPhonesRequest, CheckPhonesResponse>, callback: grpc_1.sendUnaryData<CheckPhonesResponse>): void;
         abstract MarkChatUnread(call: grpc_1.ServerUnaryCall<ChatUnreadRequest, Empty>, callback: grpc_1.sendUnaryData<Empty>): void;
+        abstract FetchMessageCapping(call: grpc_1.ServerUnaryCall<Session, Json>, callback: grpc_1.sendUnaryData<Json>): void;
         abstract GenerateNewMessageID(call: grpc_1.ServerUnaryCall<Session, NewMessageIDResponse>, callback: grpc_1.sendUnaryData<NewMessageIDResponse>): void;
         abstract SendMessage(call: grpc_1.ServerUnaryCall<MessageRequest, MessageResponse>, callback: grpc_1.sendUnaryData<MessageResponse>): void;
         abstract SendReaction(call: grpc_1.ServerUnaryCall<MessageReaction, MessageResponse>, callback: grpc_1.sendUnaryData<MessageResponse>): void;
@@ -11894,6 +11904,9 @@ export namespace messages {
         };
         MarkChatUnread: GrpcUnaryServiceInterface<ChatUnreadRequest, Empty> = (message: ChatUnreadRequest, metadata: grpc_1.Metadata | grpc_1.CallOptions | grpc_1.requestCallback<Empty>, options?: grpc_1.CallOptions | grpc_1.requestCallback<Empty>, callback?: grpc_1.requestCallback<Empty>): grpc_1.ClientUnaryCall => {
             return super.MarkChatUnread(message, metadata, options, callback);
+        };
+        FetchMessageCapping: GrpcUnaryServiceInterface<Session, Json> = (message: Session, metadata: grpc_1.Metadata | grpc_1.CallOptions | grpc_1.requestCallback<Json>, options?: grpc_1.CallOptions | grpc_1.requestCallback<Json>, callback?: grpc_1.requestCallback<Json>): grpc_1.ClientUnaryCall => {
+            return super.FetchMessageCapping(message, metadata, options, callback);
         };
         GenerateNewMessageID: GrpcUnaryServiceInterface<Session, NewMessageIDResponse> = (message: Session, metadata: grpc_1.Metadata | grpc_1.CallOptions | grpc_1.requestCallback<NewMessageIDResponse>, options?: grpc_1.CallOptions | grpc_1.requestCallback<NewMessageIDResponse>, callback?: grpc_1.requestCallback<NewMessageIDResponse>): grpc_1.ClientUnaryCall => {
             return super.GenerateNewMessageID(message, metadata, options, callback);

--- a/src/core/engines/gows/grpc/gows_grpc_pb.js
+++ b/src/core/engines/gows/grpc/gows_grpc_pb.js
@@ -709,9 +709,9 @@ function deserialize_messages_UpsertLabelRequest(buffer_arg) {
 }
 
 
-//
+// 
 // Events
-//
+// 
 var EventStreamService = exports.EventStreamService = {
   streamEvents: {
     path: '/messages.EventStream/StreamEvents',
@@ -728,9 +728,9 @@ var EventStreamService = exports.EventStreamService = {
 
 exports.EventStreamClient = grpc.makeGenericClientConstructor(EventStreamService, 'EventStream');
 var MessageServiceService = exports.MessageServiceService = {
-  //
+  // 
 // Session management
-//
+// 
 startSession: {
     path: '/messages.MessageService/StartSession',
     requestStream: false,
@@ -808,9 +808,9 @@ startSession: {
     responseSerialize: serialize_messages_Empty,
     responseDeserialize: deserialize_messages_Empty,
   },
-  //
+  // 
 // Profile
-//
+// 
 setProfileName: {
     path: '/messages.MessageService/SetProfileName',
     requestStream: false,
@@ -844,9 +844,9 @@ setProfileName: {
     responseSerialize: serialize_messages_Empty,
     responseDeserialize: deserialize_messages_Empty,
   },
-  //
+  // 
 // Lids
-//
+// 
 getAllLids: {
     path: '/messages.MessageService/GetAllLids',
     requestStream: false,
@@ -891,9 +891,9 @@ getAllLids: {
     responseSerialize: serialize_messages_OptionalString,
     responseDeserialize: deserialize_messages_OptionalString,
   },
-  //
+  // 
 // Groups
-//
+// 
 fetchGroups: {
     path: '/messages.MessageService/FetchGroups',
     requestStream: false,
@@ -1073,9 +1073,9 @@ updateGroupParticipants: {
     responseSerialize: serialize_messages_JsonList,
     responseDeserialize: deserialize_messages_JsonList,
   },
-  //
+  // 
 // Actions
-//
+// 
 getProfilePicture: {
     path: '/messages.MessageService/GetProfilePicture',
     requestStream: false,
@@ -1142,9 +1142,24 @@ getProfilePicture: {
     responseSerialize: serialize_messages_Empty,
     responseDeserialize: deserialize_messages_Empty,
   },
-  //
+  // 
+// Account
+// 
+// Fetch the account's current new-chat message capping (per-cycle quota).
+fetchMessageCapping: {
+    path: '/messages.MessageService/FetchMessageCapping',
+    requestStream: false,
+    responseStream: false,
+    requestType: gows_pb.Session,
+    responseType: gows_pb.Json,
+    requestSerialize: serialize_messages_Session,
+    requestDeserialize: deserialize_messages_Session,
+    responseSerialize: serialize_messages_Json,
+    responseDeserialize: deserialize_messages_Json,
+  },
+  // 
 // Message
-//
+// 
 generateNewMessageID: {
     path: '/messages.MessageService/GenerateNewMessageID',
     requestStream: false,
@@ -1222,9 +1237,9 @@ generateNewMessageID: {
     responseSerialize: serialize_messages_MessageResponse,
     responseDeserialize: deserialize_messages_MessageResponse,
   },
-  //
+  // 
 // Newsletters
-//
+// 
 getSubscribedNewsletters: {
     path: '/messages.MessageService/GetSubscribedNewsletters',
     requestStream: false,
@@ -1313,9 +1328,9 @@ getSubscribedNewsletters: {
     responseSerialize: serialize_messages_Empty,
     responseDeserialize: deserialize_messages_Empty,
   },
-  //
+  // 
 // Labels
-//
+// 
 getLabels: {
     path: '/messages.MessageService/GetLabels',
     requestStream: false,
@@ -1393,9 +1408,9 @@ getLabels: {
     responseSerialize: serialize_messages_JsonList,
     responseDeserialize: deserialize_messages_JsonList,
   },
-  //
+  // 
 // Contacts
-//
+// 
 updateContact: {
     path: '/messages.MessageService/UpdateContact',
     requestStream: false,
@@ -1429,9 +1444,9 @@ updateContact: {
     responseSerialize: serialize_messages_Json,
     responseDeserialize: deserialize_messages_Json,
   },
-  //
+  // 
 // Events
-//
+// 
 cancelEventMessage: {
     path: '/messages.MessageService/CancelEventMessage',
     requestStream: false,
@@ -1443,9 +1458,9 @@ cancelEventMessage: {
     responseSerialize: serialize_messages_MessageResponse,
     responseDeserialize: deserialize_messages_MessageResponse,
   },
-  //
+  // 
 // Media
-//
+// 
 downloadMedia: {
     path: '/messages.MessageService/DownloadMedia',
     requestStream: false,
@@ -1457,9 +1472,9 @@ downloadMedia: {
     responseSerialize: serialize_messages_DownloadMediaResponse,
     responseDeserialize: deserialize_messages_DownloadMediaResponse,
   },
-  //
+  // 
 // Calls
-//
+// 
 rejectCall: {
     path: '/messages.MessageService/RejectCall',
     requestStream: false,
@@ -1471,9 +1486,9 @@ rejectCall: {
     responseSerialize: serialize_messages_Empty,
     responseDeserialize: deserialize_messages_Empty,
   },
-  //
+  // 
 // Storage
-//
+// 
 getMessageById: {
     path: '/messages.MessageService/GetMessageById',
     requestStream: false,

--- a/src/core/engines/gows/session.gows.core.ts
+++ b/src/core/engines/gows/session.gows.core.ts
@@ -28,6 +28,7 @@ import {
   parseJsonList,
   statusToAck,
 } from '@waha/core/engines/gows/helpers';
+import { parseGowsMessageCapping } from '@waha/core/engines/gows/capping';
 import { parseGowsReachoutTimelock } from '@waha/core/engines/gows/reachouttimelock';
 import { GowsAuthFactoryCore } from '@waha/core/engines/gows/store/GowsAuthFactoryCore';
 import {
@@ -136,6 +137,7 @@ import {
 import { CallData } from '@waha/structures/calls.dto';
 import {
   MeInfo,
+  MessageCappingData,
   ProxyConfig,
   SessionConfig,
 } from '@waha/structures/sessions.dto';
@@ -238,6 +240,7 @@ enum WhatsMeowEvent {
   PUSH_NAME_SETTING = 'events.PushNameSetting',
   LOGGED_OUT = 'events.LoggedOut',
   NOTIFY_ACCOUNT_REACHOUT_TIMELOCK = 'events.NotifyAccountReachoutTimelock',
+  MESSAGE_CAPPING = 'gows.MessageCapping',
   // Groups
   GROUP_INFO = 'events.GroupInfo',
   JOINED_GROUP = 'events.JoinedGroup',
@@ -478,6 +481,9 @@ export class WhatsappSessionGoWSCore extends WhatsappSession {
     });
     events.on(WhatsMeowEvent.NOTIFY_ACCOUNT_REACHOUT_TIMELOCK, (data) => {
       this.reachoutTimelock.update(parseGowsReachoutTimelock(data));
+    });
+    events.on(WhatsMeowEvent.MESSAGE_CAPPING, (data) => {
+      this.messageCapping.update(parseGowsMessageCapping(data));
     });
     events.on(WhatsMeowEvent.PRESENCE, (event: gows.Presence) => {
       if (isJidGroup(event.From)) {
@@ -927,7 +933,11 @@ export class WhatsappSessionGoWSCore extends WhatsappSession {
     if (!this.me) {
       return null;
     }
-    return { ...this.me, reachoutTimelock: this.reachoutTimelock.value };
+    return {
+      ...this.me,
+      reachoutTimelock: this.reachoutTimelock.value,
+      messageCapping: this.messageCapping.value,
+    };
   }
 
   /**
@@ -2273,6 +2283,17 @@ export class WhatsappSessionGoWSCore extends WhatsappSession {
     const response = await promisify(this.client.GetContactById)(request);
     const data = parseJson(response);
     return this.toWAContact(data);
+  }
+
+  @Activity()
+  public async fetchMessageCapping(): Promise<MessageCappingData> {
+    const response = await promisify(this.client.FetchMessageCapping)(
+      this.session,
+    );
+    const capping = parseGowsMessageCapping(parseJson(response));
+    // Keep the tracker in sync so MeInfo and 'session.status' reflect the fetch
+    this.messageCapping.update(capping);
+    return capping;
   }
 
   public async getContacts(pagination: PaginationParams) {

--- a/src/structures/sessions.dto.ts
+++ b/src/structures/sessions.dto.ts
@@ -375,6 +375,71 @@ export class ReachoutTimelockData {
   timeEnforcementEnds: number | null;
 }
 
+/**
+ * Capping status for the per-cycle new-chat message quota.
+ * WhatsApp may introduce new values at any time - treat it as an open set.
+ */
+export enum MessageCappingStatus {
+  NONE = 'NONE',
+  FIRST_WARNING = 'FIRST_WARNING',
+  SECOND_WARNING = 'SECOND_WARNING',
+  CAPPED = 'CAPPED',
+}
+
+export class MessageCappingData {
+  @ApiProperty({
+    example: MessageCappingStatus.FIRST_WARNING,
+    enum: MessageCappingStatus,
+    description:
+      'How close the account is to its new-chat quota. ' +
+      'CAPPED means new chats are blocked. WhatsApp may introduce new values, ' +
+      'so treat it as an open set.',
+  })
+  cappingStatus: MessageCappingStatus;
+
+  @ApiProperty({
+    example: 1000,
+    description:
+      'New-chat messages allowed in the current cycle. -1 when the account ' +
+      'has no cap.',
+  })
+  totalQuota: number;
+
+  @ApiProperty({
+    example: 640,
+    description: 'New-chat messages already used in the current cycle.',
+  })
+  usedQuota: number;
+
+  @ApiProperty({
+    example: 1782874800,
+    nullable: true,
+    description: 'Unix timestamp (seconds) when the current cycle started.',
+  })
+  cycleStart: number | null;
+
+  @ApiProperty({
+    example: 1785553199,
+    nullable: true,
+    description: 'Unix timestamp (seconds) when the current cycle ends.',
+  })
+  cycleEnd: number | null;
+
+  @ApiProperty({
+    example: 'NOT_ELIGIBLE',
+    nullable: true,
+    description: 'Meta Verified status. Informational.',
+  })
+  mvStatus: string | null;
+
+  @ApiProperty({
+    example: 'NOT_ELIGIBLE',
+    nullable: true,
+    description: 'One-time engagement status. Informational.',
+  })
+  oteStatus: string | null;
+}
+
 export class MeInfo {
   @ChatIdProperty()
   id: string;
@@ -400,6 +465,15 @@ export class MeInfo {
       'Null if no enforcement has been seen for the account.',
   })
   reachoutTimelock?: ReachoutTimelockData | null;
+
+  @ApiProperty({
+    required: false,
+    nullable: true,
+    description:
+      'WhatsApp new-chat message capping (per-cycle quota) info. ' +
+      'Null until the capping state has been fetched for the account.',
+  })
+  messageCapping?: MessageCappingData | null;
 }
 
 export class SessionInfo extends SessionDTO {


### PR DESCRIPTION
Exposes WhatsApp's **new-chat message capping** (per-cycle quota) in the API — the
volume counterpart of the reachout timelock. It tells how close an account is to
its limit for starting new chats (`NONE` → `FIRST_WARNING` → `SECOND_WARNING` →
`CAPPED`), so integrators can throttle before hitting a 463 or a hard cap.

This mirrors the reachout timelock end to end.

## What it adds

- **`MessageCappingData` + `MessageCappingStatus`** (`sessions.dto.ts`):
  `cappingStatus`, `totalQuota` (`-1` = no cap), `usedQuota`, `cycleStart`,
  `cycleEnd`, `mvStatus`, `oteStatus`.
- **`MeInfo.messageCapping`** — the value is available in the session info, next to
  `reachoutTimelock`.
- **`MessageCappingTracker`** (`session.abc.ts`) — keeps the latest state and
  re-issues `WORKING` so `session.status` consumers get the change (like the
  timelock). Unlike the timelock there is no client-side expiry: the cycle resets
  on the server and the state is refreshed by re-fetching.
- **`GET /api/sessions/{session}/capping`** — fetches a fresh value on demand
  (GOWS only). Useful because the capping is dynamic.
- **`sessions-capping` MCP tool** — wraps the endpoint.

The GOWS engine fetches the value on connect, on a timelock change, on a 463, and
periodically; the `session.status` event and `MeInfo` reflect it.

## Dependency / merge order

The `GET .../capping` endpoint calls a new `FetchMessageCapping` gRPC added in
gows-plus (companion PR). The generated `grpc/gows.ts` stub in this branch was
regenerated from that proto locally; a real build needs a gows release that
includes the RPC. Suggested order: land the gows-plus PR and cut a gows release
first, then this PR with the matching gows ref bump.

## Testing

Validated locally with the GOWS engine against a real account: the endpoint
returns the fresh capping, `me.messageCapping` is populated, and the
`session.status` webhook carries `messageCapping` on change. A clean account
reports `NONE` / `totalQuota: -1`; the warning/capped states require an account
that is actually near its limit (same constraint as the timelock). `tsc --noEmit`
and lint are clean.

PR GOWS > https://github.com/devlikeapro/gows-plus/pull/4

[![patron:PRO](https://img.shields.io/badge/patron-PRO-188a42)](https://waha.devlike.pro/docs/how-to/plus-version/#tiers)