### PR TITLE
[cherry-pick] fix WEBJS LID presence and GOWS chat summaries

### DIFF
--- a/src/core/engines/gows/session.gows.core.ts
+++ b/src/core/engines/gows/session.gows.core.ts
@@ -2350,7 +2350,23 @@ export class WhatsappSessionGoWSCore extends WhatsappSession {
 
   protected async fetchChatSummary(chat, merge: boolean): Promise<ChatSummary> {
     const id = toCusFormat(chat.id);
-    const name = chat.name;
+    let name = chat.name;
+    if (!name) {
+      try {
+        const jid = toJID(chat.id);
+        const request = new messages.EntityByIdRequest({
+          session: this.session,
+          id: jid,
+        });
+        const response = await promisify(this.client.GetContactById)(request);
+        const contactData = parseJson(response);
+        if (contactData) {
+          name = contactData.Name || contactData.PushName;
+        }
+      } catch (e) {
+        // Ignore contact lookup errors
+      }
+    }
     const picture = await this.getContactProfilePicture(chat.id, false);
     const lastMessageQuery: GetChatMessagesQuery = {
       limit: 1,

--- a/src/core/engines/webjs/session.webjs.core.ts
+++ b/src/core/engines/webjs/session.webjs.core.ts
@@ -1855,14 +1855,26 @@ export class WhatsappSessionWebJSCore extends WhatsappSession {
 
   @Activity()
   public async getPresence(id: string): Promise<WAHAChatPresences> {
-    const chatId = toCusFormat(id);
+    let chatId = toCusFormat(id);
+    if (isLidUser(chatId)) {
+      const pn = await this.whatsapp.findPNByLid(chatId);
+      if (pn) {
+        chatId = toCusFormat(pn);
+      }
+    }
     const presences = await this.whatsapp.getPresence(chatId);
     return this.toWahaPresences(chatId, presences);
   }
 
   @Activity()
   public async subscribePresence(id: string): Promise<any> {
-    const chatId = toCusFormat(id);
+    let chatId = toCusFormat(id);
+    if (isLidUser(chatId)) {
+      const pn = await this.whatsapp.findPNByLid(chatId);
+      if (pn) {
+        chatId = toCusFormat(pn);
+      }
+    }
     await this.whatsapp.subscribePresence(chatId);
   }
 


### PR DESCRIPTION
This PR intentionally contains only the cherry-picked commit 0f40118ca63171a11e00e56bb197c0eed9e3ad45.\n\nOriginal author: Niels (np@sf-solutions.net)\nCommitter in our fork: Syakur Rahman\nSource branch: shaqman:codex/upstream-cherry-pick-webjs-presence\n\nThe commit adds the GOWS contact-name fallback and the initial WEBJS @lid presence conversion. It is separated from our follow-up fixes so attribution and review scope are clear.