### PR TITLE
[follow-up] improve WebJS LID sends and failure diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "undici": "^7.16.0",
     "uniqid": "^5.4.0",
     "user-agents": "^1.1.669",
-    "whatsapp-web.js": "github:devlikeapro/whatsapp-web.js#fork-main-2026-06-26",
+    "whatsapp-web.js": "github:shaqman/whatsapp-web.js#codex/pn-sender-for-lid-cold-contacts",
     "write-file-atomic": "^6.0.0",
     "yaml": "^2.7.1",
     "zod": "^4.3.6"

--- a/src/core/engines/gows/session.gows.core.ts
+++ b/src/core/engines/gows/session.gows.core.ts
@@ -2358,8 +2358,12 @@ export class WhatsappSessionGoWSCore extends WhatsappSession {
       downloadMedia: false,
       merge,
     };
-    const messages = await this.getChatMessages(chat.id, lastMessageQuery, {});
-    const message = messages.length > 0 ? messages[0] : null;
+    const chatMessages = await this.getChatMessages(
+      chat.id,
+      lastMessageQuery,
+      {},
+    );
+    const message = chatMessages.length > 0 ? chatMessages[0] : null;
     return {
       id: id,
       name: name || null,

--- a/src/core/engines/webjs/WebjsClientCore.test.ts
+++ b/src/core/engines/webjs/WebjsClientCore.test.ts
@@ -1,0 +1,18 @@
+import { getPresenceSubscriptionMethod } from './WebjsClientCore';
+
+describe('getPresenceSubscriptionMethod', () => {
+  it('uses the user presence bridge for direct chats and LIDs', () => {
+    expect(getPresenceSubscriptionMethod('123@c.us')).toBe(
+      'subscribeUserPresence',
+    );
+    expect(getPresenceSubscriptionMethod('123@lid')).toBe(
+      'subscribeUserPresence',
+    );
+  });
+
+  it('uses the group presence bridge for group chats', () => {
+    expect(getPresenceSubscriptionMethod('123@g.us')).toBe(
+      'subscribeGroupPresence',
+    );
+  });
+});

--- a/src/core/engines/webjs/WebjsClientCore.ts
+++ b/src/core/engines/webjs/WebjsClientCore.ts
@@ -35,6 +35,12 @@ export interface WebjsChannelMessage {
   viewCount: number;
 }
 
+export function getPresenceSubscriptionMethod(chatId: string): string {
+  return chatId.endsWith('@g.us')
+    ? 'subscribeGroupPresence'
+    : 'subscribeUserPresence';
+}
+
 class ChannelMessageReaction {
   reaction: string;
   count: number;
@@ -597,16 +603,26 @@ export class WebjsClientCore extends Client {
   /**
    * Presences methods
    */
-  public async subscribePresence(chatId: string): Promise<void> {
-    await this.pupPage.evaluate(async (chatId) => {
+  public async subscribePresence(
+    chatId: string,
+    subscriptionChatId: string = chatId,
+  ): Promise<void> {
+    const method = getPresenceSubscriptionMethod(subscriptionChatId);
+    await this.pupPage.evaluate(async (chatId, method) => {
       const d = require;
       const WidFactory = d('WAWebWidFactory');
 
       const wid = WidFactory.createWidFromWidLike(chatId);
       const chat = d('WAWebChatCollection').ChatCollection.get(wid);
       const tc = chat == null ? void 0 : chat.getTcToken();
-      await d('WAWebContactPresenceBridge').subscribePresence(wid, tc);
-    }, chatId);
+      const bridge = d('WAWebContactPresenceBridge');
+      const presenceWid = method === 'subscribeUserPresence'
+        ? chatId.endsWith('@lid')
+          ? wid
+          : WidFactory.createUserLidOrThrow(wid)
+        : wid;
+      await bridge[method](presenceWid, tc);
+    }, subscriptionChatId, method);
   }
 
   private async getCurrentPresence(chatId: string): Promise<WebJSPresence[]> {
@@ -639,9 +655,12 @@ export class WebjsClientCore extends Client {
     return result;
   }
 
-  public async getPresence(chatId: string): Promise<WebJSPresence[]> {
+  public async getPresence(
+    chatId: string,
+    subscriptionChatId: string = chatId,
+  ): Promise<WebJSPresence[]> {
     await this.sendPresenceAvailable();
-    await this.subscribePresence(chatId);
+    await this.subscribePresence(chatId, subscriptionChatId);
     await sleep(3_000);
     return await this.getCurrentPresence(chatId);
   }

--- a/src/core/engines/webjs/ack.webjs.test.ts
+++ b/src/core/engines/webjs/ack.webjs.test.ts
@@ -1,0 +1,31 @@
+import {
+  getWebjsAckReason,
+  getWebjsMessageAck,
+} from './ack.webjs';
+
+describe('WebJS message acknowledgements', () => {
+  it('prefers the acknowledgement emitted with the event', () => {
+    expect(getWebjsMessageAck({ ack: 2 }, -1)).toBe(-1);
+  });
+
+  it('extracts a bounded error message for failed sends', () => {
+    expect(
+      getWebjsAckReason(
+        { rawData: { error: { message: 'recipient is not available' } } },
+        -1,
+      ),
+    ).toBe('recipient is not available');
+  });
+
+  it('provides a useful fallback when WebJS gives no error detail', () => {
+    expect(getWebjsAckReason({ rawData: {} }, -1)).toBe(
+      'WhatsApp returned ACK_ERROR before delivery',
+    );
+  });
+
+  it('does not add a reason for successful acknowledgements', () => {
+    expect(getWebjsAckReason({ rawData: { error: 'stale error' } }, 2)).toBe(
+      undefined,
+    );
+  });
+});

--- a/src/core/engines/webjs/ack.webjs.ts
+++ b/src/core/engines/webjs/ack.webjs.ts
@@ -1,7 +1,56 @@
 import type { proto } from '@adiwajshing/baileys';
 import type { BinaryNode } from '@adiwajshing/baileys';
 import { isJidGroup, isJidStatusBroadcast } from '@waha/core/utils/jids';
+import { WAMessageAck } from '@waha/structures/enums.dto';
 import esm from '@waha/vendor/esm';
+
+const MAX_ACK_REASON_LENGTH = 256;
+
+function toAckReason(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim()) {
+    return value.trim().slice(0, MAX_ACK_REASON_LENGTH);
+  }
+  if (value && typeof value === 'object') {
+    return toAckReason((value as { message?: unknown }).message);
+  }
+  return undefined;
+}
+
+/**
+ * WebJS exposes the useful send failure details on the raw message when they
+ * are available. Keep this extraction narrow because the raw object contains
+ * internal and potentially sensitive WhatsApp state.
+ */
+export function getWebjsAckReason(
+  message: any,
+  ack: number,
+): string | undefined {
+  if (ack !== WAMessageAck.ERROR) {
+    return undefined;
+  }
+
+  const data = message?.rawData ?? message?._data ?? message;
+  const candidates = [
+    data?.errorMessage,
+    data?.error,
+    data?.sendError,
+    data?.sendResult?.error,
+    data?.sendResult?.message,
+    data?.lastError,
+  ];
+  for (const candidate of candidates) {
+    const reason = toAckReason(candidate);
+    if (reason) {
+      return reason;
+    }
+  }
+
+  return 'WhatsApp returned ACK_ERROR before delivery';
+}
+
+export function getWebjsMessageAck(message: any, eventAck?: number): number {
+  return eventAck ?? message?.ack;
+}
 
 export interface ReceiptEvent {
   key: proto.IMessageKey;

--- a/src/core/engines/webjs/message-options.test.ts
+++ b/src/core/engines/webjs/message-options.test.ts
@@ -1,0 +1,21 @@
+import { getWebjsMessageOptions } from './message-options';
+
+describe('getWebjsMessageOptions', () => {
+  it('waits for WhatsApp to accept the message for sending', () => {
+    const options = getWebjsMessageOptions(
+      {
+        mentions: ['123'],
+        reply_to: 'true_123@c.us_message-id',
+        linkPreview: false,
+      },
+      (value) => `${value}@c.us`,
+    );
+
+    expect(options).toEqual({
+      mentions: ['123@c.us'],
+      quotedMessageId: 'true_123@c.us_message-id',
+      linkPreview: false,
+      waitUntilMsgSent: true,
+    });
+  });
+});

--- a/src/core/engines/webjs/message-options.ts
+++ b/src/core/engines/webjs/message-options.ts
@@ -1,0 +1,17 @@
+export function getWebjsMessageOptions(
+  request: any,
+  ensureSuffix: (value: string) => string,
+): any {
+  const mentions = request.mentions
+    ? request.mentions.map(ensureSuffix)
+    : undefined;
+  const quotedMessageId = request.reply_to || request.replyTo;
+
+  return {
+    mentions: mentions,
+    quotedMessageId: quotedMessageId,
+    linkPreview: request.linkPreview,
+    // Do not return before WhatsApp has accepted the message for sending.
+    waitUntilMsgSent: true,
+  };
+}

--- a/src/core/engines/webjs/session.webjs.core.ts
+++ b/src/core/engines/webjs/session.webjs.core.ts
@@ -11,6 +11,8 @@ import {
 import {
   ReceiptEvent,
   TagReceiptNodeToReceiptEvent,
+  getWebjsAckReason,
+  getWebjsMessageAck,
 } from '@waha/core/engines/webjs/ack.webjs';
 import {
   getParticipants,
@@ -31,6 +33,7 @@ import {
   CallErrorEvent,
   PAGE_CALL_ERROR_EVENT,
 } from '@waha/core/engines/webjs/WPage';
+import { getWebjsMessageOptions } from '@waha/core/engines/webjs/message-options';
 import { WAMimeType } from '@waha/core/media/WAMimeType';
 import { detectMimetype } from '@waha/utils/files';
 import { NotImplementedByEngineError } from '@waha/core/exceptions';
@@ -1855,15 +1858,32 @@ export class WhatsappSessionWebJSCore extends WhatsappSession {
 
   @Activity()
   public async getPresence(id: string): Promise<WAHAChatPresences> {
-    const chatId = toCusFormat(id);
-    const presences = await this.whatsapp.getPresence(chatId);
+    const subscriptionChatId = toCusFormat(id);
+    let chatId = subscriptionChatId;
+    if (isLidUser(chatId)) {
+      const pn = await this.whatsapp.findPNByLid(chatId);
+      if (pn) {
+        chatId = toCusFormat(pn);
+      }
+    }
+    const presences = await this.whatsapp.getPresence(
+      chatId,
+      subscriptionChatId,
+    );
     return this.toWahaPresences(chatId, presences);
   }
 
   @Activity()
   public async subscribePresence(id: string): Promise<any> {
-    const chatId = toCusFormat(id);
-    await this.whatsapp.subscribePresence(chatId);
+    const subscriptionChatId = toCusFormat(id);
+    let chatId = subscriptionChatId;
+    if (isLidUser(chatId)) {
+      const pn = await this.whatsapp.findPNByLid(chatId);
+      if (pn) {
+        chatId = toCusFormat(pn);
+      }
+    }
+    await this.whatsapp.subscribePresence(chatId, subscriptionChatId);
   }
 
   private toWahaPresences(
@@ -2102,8 +2122,22 @@ export class WhatsappSessionWebJSCore extends WhatsappSession {
       },
     );
     const messagesAckDM$ = messageAckWEBJS$.pipe(
-      map((event) => event.message),
-      map<any, WAMessage>(this.toWAMessage.bind(this)),
+      map((event) => {
+        const ack = this.toWAMessage(event.message, event.ack);
+        if (ack.ack === WAMessageAck.ERROR) {
+          this.logger.warn(
+            {
+              id: ack.id,
+              to: ack.to,
+              ack: ack.ack,
+              ackName: ack.ackName,
+              ackReason: ack.ackReason,
+            },
+            'WEBJS message send failed',
+          );
+        }
+        return ack;
+      }),
       filter((ack) => !isJidGroup(ack.to) && !isJidStatusBroadcast(ack.to)),
       filter((ack) => this.jids.include(ack.to)),
     );
@@ -2390,16 +2424,18 @@ export class WhatsappSessionWebJSCore extends WhatsappSession {
         fromMe: !receipt.key.fromMe, // reverted, it's right
         ack: ack,
         ackName: WAMessageAck[ack] || ACK_UNKNOWN,
+        ackReason: getWebjsAckReason(receipt._node, ack),
         _data: receipt._node,
       });
     }
     return acks;
   }
 
-  protected toWAMessage(message: Message): WAMessage {
+  protected toWAMessage(message: Message, eventAck?: number): WAMessage {
     const replyTo = this.extractReplyTo(message);
     const source = this.getMessageSource(message.id.id);
     const key = parseMessageIdSerialized(GetSerialized(message.id));
+    const ack = getWebjsMessageAck(message, eventAck);
     // @ts-ignore
     return {
       id: GetSerialized(message.id),
@@ -2417,8 +2453,9 @@ export class WhatsappSessionWebJSCore extends WhatsappSession {
       // @ts-ignore
       mediaUrl: message.media?.url,
       // @ts-ignore
-      ack: message.ack,
-      ackName: WAMessageAck[message.ack] || ACK_UNKNOWN,
+      ack: ack,
+      ackName: WAMessageAck[ack] || ACK_UNKNOWN,
+      ackReason: getWebjsAckReason(message, ack),
       location: this.extractLocation(message),
       vCards: message.vCards,
       replyTo: replyTo,
@@ -2502,16 +2539,7 @@ export class WhatsappSessionWebJSCore extends WhatsappSession {
   }
 
   protected getMessageOptions(request: any): any {
-    let mentions = request.mentions;
-    mentions = mentions ? mentions.map(this.ensureSuffix) : undefined;
-
-    const quotedMessageId = request.reply_to || request.replyTo;
-
-    return {
-      mentions: mentions,
-      quotedMessageId: quotedMessageId,
-      linkPreview: request.linkPreview,
-    };
+    return getWebjsMessageOptions(request, this.ensureSuffix);
   }
 }
 

--- a/src/structures/responses.dto.ts
+++ b/src/structures/responses.dto.ts
@@ -100,6 +100,11 @@ export class WAMessage extends WAMessageBase {
   })
   ackName: string;
 
+  /**
+   * Human-readable send failure detail when the engine reports ACK_ERROR.
+   */
+  ackReason?: string;
+
   @ApiProperty({
     description:
       'If the message was sent to a group, this field will contain the user that sent the message.',

--- a/src/structures/webhooks.dto.ts
+++ b/src/structures/webhooks.dto.ts
@@ -33,6 +33,7 @@ export class WAMessageAckBody {
   fromMe: boolean;
   ack: WAMessageAck;
   ackName: string;
+  ackReason?: string;
 
   _data?: any;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14037,7 +14037,7 @@ __metadata:
     undici: "npm:^7.16.0"
     uniqid: "npm:^5.4.0"
     user-agents: "npm:^1.1.669"
-    whatsapp-web.js: "github:devlikeapro/whatsapp-web.js#fork-main-2026-06-26"
+    whatsapp-web.js: "github:shaqman/whatsapp-web.js#codex/pn-sender-for-lid-cold-contacts"
     write-file-atomic: "npm:^6.0.0"
     yaml: "npm:^2.7.1"
     zod: "npm:^4.3.6"
@@ -14146,9 +14146,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"whatsapp-web.js@github:devlikeapro/whatsapp-web.js#fork-main-2026-06-26":
+"whatsapp-web.js@github:shaqman/whatsapp-web.js#codex/pn-sender-for-lid-cold-contacts":
   version: 1.34.7
-  resolution: "whatsapp-web.js@https://github.com/devlikeapro/whatsapp-web.js.git#commit=2daac8c8f83ddd7d92983bff8803dde970002a79"
+  resolution: "whatsapp-web.js@https://github.com/shaqman/whatsapp-web.js.git#commit=b25cced0edcb66114118b89dda342f525d17db61"
   dependencies:
     archiver: "npm:7.0.1"
     fluent-ffmpeg: "npm:2.1.3"
@@ -14165,7 +14165,7 @@ __metadata:
       optional: true
     unzipper:
       optional: true
-  checksum: 10/358d9c3e9da5f04d2db26706ba2cbf2a675efed47905d1b47319096b7739dd34e3ded8526ae5985da6b6fce9e9b931bc142a612db4af46b520bd9d55ad5ef6c9
+  checksum: 10/2991cc17e5320804a8dfe755f1243a1a30d33df098e3eb81eb65c37b2c51aff81ae4a75d39046866ba312b27eea741180c7c430e3027c45bb8ee1ab026b4cec6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #2187\n\nThis is our follow-up contribution, authored and implemented by Syakur Rahman. It is intentionally separate from the cherry-picked base in companion PR #2189 for clear attribution.\n\nSummary:\n- Correct WebJS LID presence bridge selection and direct-contact sender behavior.\n- Wait for WhatsApp send acceptance before returning from send requests.\n- Preserve explicit WebJS message_ack values.\n- Expose bounded ackReason details for ACK_ERROR events.\n- Add structured failure logging without message content.\n- Add focused unit coverage.\n\nDependency order:\n- The separate whatsapp-web.js contribution is upstream PR https://github.com/devlikeapro/whatsapp-web.js/pull/2.\n- This WAHA branch currently pins shaqman/whatsapp-web.js#codex/pn-sender-for-lid-cold-contacts until that dependency change is accepted.\n- This follow-up also builds on WAHA cherry-pick PR #2189 for the initial WEBJS presence conversion.\n\nVerification: targeted WebJS tests passed; lint passed; build passed with polling due to the host inotify watcher limit.