### PR TITLE
Fix stale WhatsApp Web version breaking all NOWEB sessions

### DIFF
--- a/src/core/engines/noweb/session.noweb.core.ts
+++ b/src/core/engines/noweb/session.noweb.core.ts
@@ -62,6 +62,7 @@ import {
 } from '@waha/core/engines/noweb/noweb.newsletter';
 import { NowebAuthFactoryCore } from '@waha/core/engines/noweb/NowebAuthFactoryCore';
 import { NowebInMemoryStore } from '@waha/core/engines/noweb/store/NowebInMemoryStore';
+import { resolveWaVersion } from '@waha/core/engines/noweb/utils';
 import { NotImplementedByEngineError } from '@waha/core/exceptions';
 import { toVcardV3 } from '@waha/core/vcard';
 import { createAgentProxy } from '@waha/core/helpers.proxy';
@@ -355,7 +356,10 @@ export class WhatsappSessionNoWebCore extends WhatsappSession {
     await this.sock?.logout();
   }
 
-  getSocketConfig(agents: Agents | undefined, state): Partial<SocketConfig> {
+  async getSocketConfig(
+    agents: Agents | undefined,
+    state,
+  ): Promise<Partial<SocketConfig>> {
     // Detect browser
     let browser = ['Ubuntu', 'Chrome', '22.04.4'] as WABrowserDescription;
     let deviceName =
@@ -391,6 +395,7 @@ export class WhatsappSessionNoWebCore extends WhatsappSession {
     if (markOnlineOnConnect == undefined) {
       markOnlineOnConnect = true;
     }
+    const version = await resolveWaVersion(this.engineLogger);
     return {
       agent: agents?.socket,
       // Baileys media upload uses Node https.request in Node runtime.
@@ -407,6 +412,7 @@ export class WhatsappSessionNoWebCore extends WhatsappSession {
       msgRetryCounterCache: this.msgRetryCounterCache,
       placeholderResendCache: this.placeholderResendCache,
       markOnlineOnConnect: markOnlineOnConnect,
+      ...(version ? { version } : {}),
     };
   }
 
@@ -425,10 +431,10 @@ export class WhatsappSessionNoWebCore extends WhatsappSession {
     }
     const { state, saveCreds } = this.authNOWEBStore;
     const agents = this.makeProxyAgents();
-    const socketConfig: SocketConfig = this.getSocketConfig(
+    const socketConfig: SocketConfig = (await this.getSocketConfig(
       agents,
       state,
-    ) as SocketConfig;
+    )) as SocketConfig;
     const sock = makeWASocket(socketConfig);
     sock.ev.on('creds.update', saveCreds);
     return sock;

--- a/src/core/engines/noweb/utils.ts
+++ b/src/core/engines/noweb/utils.ts
@@ -1,5 +1,71 @@
-import type { proto } from '@adiwajshing/baileys';
+import type { proto, WAVersion } from '@adiwajshing/baileys';
+import { fetchLatestBaileysVersion } from '@adiwajshing/baileys';
+import type { ILogger } from '@adiwajshing/baileys/lib/Utils/logger';
 import esm from '@waha/vendor/esm';
+
+/**
+ * The WhatsApp Web version baked into the bundled Baileys fork can go stale
+ * whenever WhatsApp bumps the version its servers accept, breaking every
+ * NOWEB session at once (connections stuck in STARTING -> FAILED). Resolve
+ * it in priority order so operators aren't stuck waiting for a WAHA release:
+ *   1. WAHA_NOWEB_WA_VERSION env var, e.g. "2,3000,1037641644"
+ *   2. Auto-detected latest version (cached per process; Baileys itself
+ *      falls back to its bundled default if the fetch fails)
+ */
+const AUTO_VERSION_TTL_MS = 60 * 60 * 1000; // 1h
+let cachedAutoVersion: { version: WAVersion; fetchedAt: number } | null =
+  null;
+
+export async function resolveWaVersion(
+  logger: ILogger,
+): Promise<WAVersion | undefined> {
+  const envVersion = process.env.WAHA_NOWEB_WA_VERSION;
+  if (envVersion) {
+    const parsed = envVersion.split(',').map((part) => Number(part.trim()));
+    if (parsed.length === 3 && parsed.every((n) => Number.isFinite(n))) {
+      logger.info(
+        { version: parsed },
+        'Using WhatsApp Web version from WAHA_NOWEB_WA_VERSION',
+      );
+      return parsed as WAVersion;
+    }
+    logger.warn(
+      `Ignoring WAHA_NOWEB_WA_VERSION="${envVersion}" - expected "major,minor,patch", e.g. "2,3000,1037641644"`,
+    );
+  }
+
+  const now = Date.now();
+  if (
+    cachedAutoVersion &&
+    now - cachedAutoVersion.fetchedAt < AUTO_VERSION_TTL_MS
+  ) {
+    logger.debug(
+      { version: cachedAutoVersion.version },
+      'Using cached auto-detected WhatsApp Web version',
+    );
+    return cachedAutoVersion.version;
+  }
+
+  try {
+    const { version, isLatest } = await fetchLatestBaileysVersion();
+    cachedAutoVersion = { version, fetchedAt: now };
+    if (isLatest) {
+      logger.info({ version }, 'Auto-detected latest WhatsApp Web version');
+    } else {
+      logger.warn(
+        { version },
+        'Could not auto-detect the latest WhatsApp Web version, using the bundled default - set WAHA_NOWEB_WA_VERSION to pin one explicitly',
+      );
+    }
+    return version;
+  } catch (err) {
+    logger.warn(
+      { err },
+      'Failed to resolve WhatsApp Web version, falling back to the Baileys default',
+    );
+    return undefined;
+  }
+}
 
 export function extractMediaContent(
   content: any | proto.IMessage | null | undefined,


### PR DESCRIPTION
# Fix stale WhatsApp Web version breaking all NOWEB sessions

## Problem

`@adiwajshing/baileys` is pinned to `fork-master-2026-04-28`, which bakes in a fixed WhatsApp Web version (`[2, 3000, 1035920091]`). NOWEB never overrides it in `getSocketConfig()`, so every connection uses that hardcoded value.

When WhatsApp bumps the version it accepts server-side, every NOWEB session breaks at once — connections get stuck in `STARTING` and then move to `FAILED`. This just happened again and is affecting multiple installations, e.g. #2191.

Today the only workaround is patching the compiled JS by hand inside the container (`sed -i '/markOnlineOnConnect: .../a\ version: [...]' dist/core/engines/noweb/session.noweb.core.js`), which most users can't do and which has to be redone by hand every time WhatsApp bumps again.

## Fix

`getSocketConfig()` now resolves the WhatsApp Web version in priority order, in a new `resolveWaVersion()` helper:

1. `WAHA_NOWEB_WA_VERSION` env var (e.g. `"2,3000,1037641644"`) — for pinning a known-good version explicitly, no network call.
2. Baileys' own `fetchLatestBaileysVersion()` — auto-detects the current version, cached in memory per process (1h TTL) so many sessions starting together don't all hit the network at once.
3. If both are unavailable, Baileys' own bundled default is used (unchanged behavior from today) — `fetchLatestBaileysVersion()` already falls back to it internally on network failure, so this never throws.

This is additive/backward compatible: if nothing is configured and the network fetch fails, behavior is identical to before the change.

## Testing

Verified locally against a real WhatsApp account (NOWEB engine, Docker):

- With no `WAHA_NOWEB_WA_VERSION` set: `fetchLatestBaileysVersion()` returned `[2, 3000, 1043857760]` (newer than the version people are currently sed-patching to), logged as `Auto-detected latest WhatsApp Web version`, session reached `SCAN_QR_CODE` and the version was correctly present in the outgoing registration node (`appVersion.tertiary: 1043857760`).
- With `WAHA_NOWEB_WA_VERSION=2,3000,1037641644` set: logged `Using WhatsApp Web version from WAHA_NOWEB_WA_VERSION` and that exact value was used, taking priority over auto-detection.
- `tsc --noEmit` clean.


[![patron:PRO](https://img.shields.io/badge/patron-PRO-188a42)](https://waha.devlike.pro/docs/how-to/plus-version/#tiers)