### PR TITLE
[core] Add POST /api/sendSticker for GOWS engine

### DIFF
--- a/src/api/chatting.controller.ts
+++ b/src/api/chatting.controller.ts
@@ -41,6 +41,7 @@ import {
   MessageTextRequest,
   MessageVideoRequest,
   MessageVoiceRequest,
+  MessageStickerRequest,
   NewMessageIDResponse,
   SendSeenRequest,
   WANumberExistResult,
@@ -127,6 +128,21 @@ export class ChattingController {
   async sendVoice(@Body() request: MessageVoiceRequest) {
     const whatsapp = await this.manager.getWorkingSession(request.session);
     return whatsapp.sendVoice(request);
+  }
+
+  @Post('/sendSticker')
+  @ApiOperation({
+    summary: 'Send a sticker',
+    description:
+      'Send a WhatsApp sticker as WebP (static or animated). ' +
+      'Either from an URL or base64 data. ' +
+      'The file must already be a valid sticker WebP (typically 512x512; ' +
+      'static ≤100KB, animated ≤500KB). No server-side conversion.',
+  })
+  @CheckPolicies(CanSession(Action.Send, FromBody('session')))
+  async sendSticker(@Body() request: MessageStickerRequest) {
+    const whatsapp = await this.manager.getWorkingSession(request.session);
+    return whatsapp.sendSticker(request);
   }
 
   @Post('/sendVideo')

--- a/src/apps/app_sdk/waha/WAHASelf.ts
+++ b/src/apps/app_sdk/waha/WAHASelf.ts
@@ -7,6 +7,7 @@ import {
   ChatRequest,
   MessageFileRequest,
   MessageImageRequest,
+  MessageStickerRequest,
   MessageTextRequest,
   MessageVideoRequest,
   MessageVoiceRequest,
@@ -220,6 +221,16 @@ export class WAHASelf {
       .then((response) => response.data);
   }
 
+  async sendSticker(
+    body: MessageStickerRequest,
+    opts?: RequestOptions,
+  ): Promise<any> {
+    const url = `/api/sendSticker`;
+    return await this.client
+      .post(url, body, { signal: opts?.signal })
+      .then((response) => response.data);
+  }
+
   async sendFile(
     body: MessageFileRequest,
     opts?: RequestOptions,
@@ -416,6 +427,11 @@ export class WAHASessionAPI {
   sendVoice(body: MessageVoiceRequest, opts?: RequestOptions): Promise<any> {
     body.session = this.session;
     return this.api.sendVoice(body, opts);
+  }
+
+  sendSticker(body: MessageStickerRequest, opts?: RequestOptions): Promise<any> {
+    body.session = this.session;
+    return this.api.sendSticker(body, opts);
   }
 
   sendFile(body: MessageFileRequest, opts?: RequestOptions): Promise<any> {

--- a/src/core/abc/session.abc.ts
+++ b/src/core/abc/session.abc.ts
@@ -87,6 +87,7 @@ import {
   MessageTextRequest,
   MessageVideoRequest,
   MessageVoiceRequest,
+  MessageStickerRequest,
   SendSeenRequest,
 } from '../../structures/chatting.dto';
 import {
@@ -604,6 +605,10 @@ export abstract class WhatsappSession {
   abstract sendFile(request: MessageFileRequest);
 
   abstract sendVoice(request: MessageVoiceRequest);
+
+  sendSticker(request: MessageStickerRequest) {
+    throw new NotImplementedByEngineError();
+  }
 
   sendVideo(request: MessageVideoRequest) {
     throw new NotImplementedByEngineError();

--- a/src/core/engines/gows/grpc/gows.ts
+++ b/src/core/engines/gows/grpc/gows.ts
@@ -24,7 +24,8 @@ export namespace messages {
         AUDIO = 1,
         VIDEO = 2,
         DOCUMENT = 3,
-        PTV = 4
+        PTV = 4,
+        STICKER = 5
     }
     export enum Presence {
         AVAILABLE = 0,
@@ -11362,6 +11363,15 @@ export namespace messages {
                 responseSerialize: (message: Empty) => Buffer.from(message.serialize()),
                 responseDeserialize: (bytes: Buffer) => Empty.deserialize(new Uint8Array(bytes))
             },
+            SetGroupMemberAddMode: {
+                path: "/messages.MessageService/SetGroupMemberAddMode",
+                requestStream: false,
+                responseStream: false,
+                requestSerialize: (message: JidBoolRequest) => Buffer.from(message.serialize()),
+                requestDeserialize: (bytes: Buffer) => JidBoolRequest.deserialize(new Uint8Array(bytes)),
+                responseSerialize: (message: Empty) => Buffer.from(message.serialize()),
+                responseDeserialize: (bytes: Buffer) => Empty.deserialize(new Uint8Array(bytes))
+            },
             UpdateGroupParticipants: {
                 path: "/messages.MessageService/UpdateGroupParticipants",
                 requestStream: false,
@@ -11734,6 +11744,7 @@ export namespace messages {
         abstract SetGroupPicture(call: grpc_1.ServerUnaryCall<SetPictureRequest, Empty>, callback: grpc_1.sendUnaryData<Empty>): void;
         abstract SetGroupLocked(call: grpc_1.ServerUnaryCall<JidBoolRequest, Empty>, callback: grpc_1.sendUnaryData<Empty>): void;
         abstract SetGroupAnnounce(call: grpc_1.ServerUnaryCall<JidBoolRequest, Empty>, callback: grpc_1.sendUnaryData<Empty>): void;
+        abstract SetGroupMemberAddMode(call: grpc_1.ServerUnaryCall<JidBoolRequest, Empty>, callback: grpc_1.sendUnaryData<Empty>): void;
         abstract UpdateGroupParticipants(call: grpc_1.ServerUnaryCall<UpdateParticipantsRequest, JsonList>, callback: grpc_1.sendUnaryData<JsonList>): void;
         abstract GetProfilePicture(call: grpc_1.ServerUnaryCall<ProfilePictureRequest, ProfilePictureResponse>, callback: grpc_1.sendUnaryData<ProfilePictureResponse>): void;
         abstract SendPresence(call: grpc_1.ServerUnaryCall<PresenceRequest, Empty>, callback: grpc_1.sendUnaryData<Empty>): void;
@@ -11860,6 +11871,9 @@ export namespace messages {
         };
         SetGroupAnnounce: GrpcUnaryServiceInterface<JidBoolRequest, Empty> = (message: JidBoolRequest, metadata: grpc_1.Metadata | grpc_1.CallOptions | grpc_1.requestCallback<Empty>, options?: grpc_1.CallOptions | grpc_1.requestCallback<Empty>, callback?: grpc_1.requestCallback<Empty>): grpc_1.ClientUnaryCall => {
             return super.SetGroupAnnounce(message, metadata, options, callback);
+        };
+        SetGroupMemberAddMode: GrpcUnaryServiceInterface<JidBoolRequest, Empty> = (message: JidBoolRequest, metadata: grpc_1.Metadata | grpc_1.CallOptions | grpc_1.requestCallback<Empty>, options?: grpc_1.CallOptions | grpc_1.requestCallback<Empty>, callback?: grpc_1.requestCallback<Empty>): grpc_1.ClientUnaryCall => {
+            return super.SetGroupMemberAddMode(message, metadata, options, callback);
         };
         UpdateGroupParticipants: GrpcUnaryServiceInterface<UpdateParticipantsRequest, JsonList> = (message: UpdateParticipantsRequest, metadata: grpc_1.Metadata | grpc_1.CallOptions | grpc_1.requestCallback<JsonList>, options?: grpc_1.CallOptions | grpc_1.requestCallback<JsonList>, callback?: grpc_1.requestCallback<JsonList>): grpc_1.ClientUnaryCall => {
             return super.UpdateGroupParticipants(message, metadata, options, callback);

--- a/src/core/engines/gows/grpc/gows_grpc_pb.js
+++ b/src/core/engines/gows/grpc/gows_grpc_pb.js
@@ -1050,6 +1050,18 @@ setGroupAnnounce: {
     responseDeserialize: deserialize_messages_Empty,
   },
   // send messages only by admins
+setGroupMemberAddMode: {
+    path: '/messages.MessageService/SetGroupMemberAddMode',
+    requestStream: false,
+    responseStream: false,
+    requestType: gows_pb.JidBoolRequest,
+    responseType: gows_pb.Empty,
+    requestSerialize: serialize_messages_JidBoolRequest,
+    requestDeserialize: deserialize_messages_JidBoolRequest,
+    responseSerialize: serialize_messages_Empty,
+    responseDeserialize: deserialize_messages_Empty,
+  },
+  // who can add members - true - all members, false - admins only
 updateGroupParticipants: {
     path: '/messages.MessageService/UpdateGroupParticipants',
     requestStream: false,

--- a/src/core/engines/gows/grpc/gows_pb.js
+++ b/src/core/engines/gows/grpc/gows_pb.js
@@ -22727,7 +22727,8 @@ proto.messages.MediaType = {
   AUDIO: 1,
   VIDEO: 2,
   DOCUMENT: 3,
-  PTV: 4
+  PTV: 4,
+  STICKER: 5
 };
 
 /**

--- a/src/core/engines/gows/session.gows.core.ts
+++ b/src/core/engines/gows/session.gows.core.ts
@@ -94,6 +94,7 @@ import {
   MessageTextRequest,
   MessageVideoRequest,
   MessageVoiceRequest,
+  MessageStickerRequest,
   SendSeenRequest,
   WANumberExistResult,
 } from '@waha/structures/chatting.dto';
@@ -1294,6 +1295,14 @@ export class WhatsappSessionGoWSCore extends WhatsappSession {
       type === messages.MediaType.PTV
     ) {
       media.mimetype = media.mimetype || WAMimeType.VIDEO;
+    } else if (type === messages.MediaType.STICKER) {
+      media.mimetype = media.mimetype || WAMimeType.STICKER;
+      if (!isWebPBuffer(Buffer.from(media.content as Uint8Array))) {
+        throw new UnprocessableEntityException(
+          `Sticker file must be a WebP image (RIFF/WEBP). ` +
+            'Convert jpg/png/gif/mp4 to WebP on the client before calling /api/sendSticker.',
+        );
+      }
     } else if (type === messages.MediaType.DOCUMENT) {
       if (!media.mimetype) {
         media.mimetype = await detectMimetype(media.content as Buffer);
@@ -1405,6 +1414,18 @@ export class WhatsappSessionGoWSCore extends WhatsappSession {
   @Activity()
   async sendVoice(request: MessageVoiceRequest) {
     return await this.sendMedia(messages.MediaType.AUDIO, request);
+  }
+
+  @Activity()
+  async sendSticker(request: MessageStickerRequest) {
+    const mimetype = request.file?.mimetype;
+    if (mimetype && mimetype !== WAMimeType.STICKER) {
+      throw new UnprocessableEntityException(
+        `Sticker mimetype must be '${WAMimeType.STICKER}', got '${mimetype}'. ` +
+          'Provide a WhatsApp-valid WebP (typically 512x512; static ≤100KB, animated ≤500KB).',
+      );
+    }
+    return await this.sendMedia(messages.MediaType.STICKER, request);
   }
 
   @Activity()
@@ -3020,6 +3041,19 @@ export class WhatsappSessionGoWSCore extends WhatsappSession {
     };
     return buildMessageId(info);
   }
+}
+
+/**
+ * True when buffer starts with RIFF....WEBP (WhatsApp sticker container).
+ */
+function isWebPBuffer(data: Buffer): boolean {
+  if (!data || data.length < 12) {
+    return false;
+  }
+  return (
+    data.subarray(0, 4).toString('ascii') === 'RIFF' &&
+    data.subarray(8, 12).toString('ascii') === 'WEBP'
+  );
 }
 
 /**

--- a/src/core/media/WAMimeType.ts
+++ b/src/core/media/WAMimeType.ts
@@ -2,4 +2,5 @@ export enum WAMimeType {
   VOICE = 'audio/ogg; codecs=opus',
   VIDEO = 'video/mp4',
   IMAGE = 'image/jpeg',
+  STICKER = 'image/webp',
 }

--- a/src/structures/chatting.dto.ts
+++ b/src/structures/chatting.dto.ts
@@ -29,6 +29,8 @@ import {
   FileType,
   FileURL,
   RemoteFile,
+  StickerBinaryFile,
+  StickerRemoteFile,
   VideoBinaryFile,
   VideoRemoteFile,
   VoiceBinaryFile,
@@ -347,6 +349,23 @@ export class MessageVoiceRequest extends ChatRequest {
 
   @ConvertApiProperty()
   convert: boolean;
+}
+
+@ApiExtraModels(StickerBinaryFile, StickerRemoteFile)
+export class MessageStickerRequest extends ChatRequest {
+  @ApiProperty({
+    description:
+      'WhatsApp-valid WebP sticker. Must be image/webp, typically 512x512. ' +
+      'Static ≤100KB, animated ≤500KB / ≤10s. Conversion is client-side.',
+    oneOf: [
+      { $ref: getSchemaPath(StickerRemoteFile) },
+      { $ref: getSchemaPath(StickerBinaryFile) },
+    ],
+  })
+  file: StickerBinaryFile | StickerRemoteFile;
+
+  @ReplyToProperty()
+  reply_to?: string;
 }
 
 @ApiExtraModels(VideoRemoteFile, VideoBinaryFile)

--- a/src/structures/files.dto.ts
+++ b/src/structures/files.dto.ts
@@ -120,6 +120,43 @@ export class VideoRemoteFile {
   url: string;
 }
 
+export class StickerBinaryFile {
+  @ApiProperty({
+    description:
+      'MIME type of the sticker. Must be image/webp (static or animated).',
+    example: 'image/webp',
+  })
+  mimetype = 'image/webp';
+
+  @ApiProperty({
+    description: 'Document file name. Optional',
+    example: 'sticker.webp',
+  })
+  filename = 'sticker.webp';
+
+  @ApiProperty({
+    description: 'Base64-encoded WebP sticker data',
+  })
+  data: string;
+}
+
+export class StickerRemoteFile {
+  @ApiProperty({
+    description:
+      'MIME type of the sticker. Must be image/webp (static or animated).',
+    example: 'image/webp',
+  })
+  mimetype = 'image/webp';
+
+  @ApiProperty({
+    description: 'URL of a WhatsApp-valid WebP sticker (512x512).',
+    example:
+      process.env.WHATSAPP_SWAGGER_STICKER_EXAMPLE_URL ||
+      'https://github.com/devlikeapro/waha/raw/core/examples/sticker.webp',
+  })
+  url: string;
+}
+
 export class FileURL {
   @IsString()
   @IsNotEmpty()

--- a/waha.config.json
+++ b/waha.config.json
@@ -1,8 +1,8 @@
 {
   "waha": {
     "gows": {
-      "repo": "devlikeapro/gows-plus",
-      "ref": "v1.0.43"
+      "repo": "SimStm/gows-plus",
+      "ref": "v1.0.45-send-sticker"
     },
     "dashboard": {
       "repo": "devlikeapro/dashboard",


### PR DESCRIPTION
## Summary
- Adds `POST /api/sendSticker` (session, chatId, file url/base64, reply_to).
- Implements sticker send on **GOWS** only; other engines keep `NotImplementedByEngineError`.
- Validates `image/webp` mimetype and RIFF/WEBP magic bytes.
- Regenerates GOWS gRPC stubs for `MediaType.STICKER`.
- Bumps `waha.config.json` to the fork tag that will carry the matching gows binary (`SimStm/gows-plus` / `v1.0.45-send-sticker`) — **release not published yet** pending license confirmation for gows-plus (no LICENSE file upstream).

Depends on: https://github.com/devlikeapro/gows-plus/pull/5  
Related: https://github.com/devlikeapro/waha/issues/1287  
API shape comment: https://github.com/devlikeapro/waha/issues/1287#issuecomment-5113702629

## Out of scope
- Server-side conversion to WebP
- EXIF pack/author injection
- MCP tool (awaiting confirmation whether parity is desired)

## Test plan
- [ ] GOWS session: static WebP → sticker (not image/document)
- [ ] Animated WebP → animated sticker
- [ ] `reply_to` works
- [ ] DM and group
- [ ] NOWEB/WEBJS → not-implemented error (not 500)
- [ ] Non-WebP → clear validation error