### PR TITLE
[core] fix(Chatwoot): sanitize attachment base64 content in consumer …

### DIFF
--- a/src/apps/chatwoot/consumers/waha/base.test.ts
+++ b/src/apps/chatwoot/consumers/waha/base.test.ts
@@ -1,0 +1,112 @@
+jest.mock('@adiwajshing/baileys', () => ({}));
+
+import {
+  ChatWootMessagePartial,
+  MessageBaseHandler,
+  MessageBaseHandlerPayload,
+} from './base';
+import { SendAttachment } from '@waha/apps/chatwoot/client/types';
+
+class TestableMessageBaseHandler extends MessageBaseHandler<MessageBaseHandlerPayload> {
+  public mockAttachments: SendAttachment[] = [];
+
+  protected async getMessage(
+    payload: MessageBaseHandlerPayload,
+  ): Promise<ChatWootMessagePartial> {
+    return {
+      content: 'Sample media caption',
+      attachments: this.mockAttachments,
+      private: false,
+    };
+  }
+
+  getReplyToWhatsAppID(
+    payload: MessageBaseHandlerPayload,
+  ): string | undefined {
+    return undefined;
+  }
+}
+
+describe('MessageBaseHandler', () => {
+  it('should sanitize attachment content to empty string on handle return', async () => {
+    const heavyBase64Payload = 'A'.repeat(1024 * 1024);
+
+    const mockJob: any = {
+      id: 'job-1',
+      data: {},
+    };
+    const mockMappingService: any = {
+      getChatWootMessage: jest.fn().mockResolvedValue(null),
+      map: jest.fn().mockResolvedValue(undefined),
+    };
+    const mockConversation: any = {
+      conversationId: 101,
+      send: jest.fn().mockResolvedValue({
+        id: 555,
+        conversation_id: 101,
+        created_at: 1700000000,
+      }),
+    };
+    const mockRepo: any = {
+      ConversationByContact: jest.fn().mockResolvedValue(mockConversation),
+    };
+    const mockLogger: any = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    const mockInfo: any = {
+      onConversationId: jest.fn(),
+      onMessageType: jest.fn(),
+    };
+    const mockSession: any = {
+      getContact: jest.fn().mockResolvedValue({ name: 'User' }),
+    };
+    const mockLocale: any = {
+      key: jest.fn().mockReturnValue({ render: jest.fn().mockReturnValue('') }),
+      r: jest.fn().mockReturnValue(''),
+      ParseTimestamp: jest.fn().mockReturnValue(new Date()),
+      FormatHumanDate: jest.fn().mockReturnValue('2026-07-30'),
+    };
+    const mockWaha: any = {};
+
+    const handler = new TestableMessageBaseHandler(
+      mockJob,
+      mockMappingService,
+      mockRepo,
+      mockLogger,
+      mockInfo,
+      mockSession,
+      mockLocale,
+      mockWaha,
+    );
+
+    handler.mockAttachments = [
+      {
+        content: heavyBase64Payload,
+        filename: 'document.pdf',
+        encoding: 'base64',
+      },
+    ];
+
+    const payload: MessageBaseHandlerPayload = {
+      id: 'false_555123456789@c.us_ABCDEF123456',
+      timestamp: 1700000000,
+      from: '555123456789@c.us',
+      fromMe: false,
+    };
+
+    const result = await handler.handle(payload);
+
+    expect(mockConversation.send).toHaveBeenCalledTimes(1);
+    const sentData = mockConversation.send.mock.calls[0][0];
+    expect(sentData.attachments[0].content).toBe(heavyBase64Payload);
+
+    expect(result).not.toBeNull();
+    expect(result?.attachments).toBeDefined();
+    expect(result?.attachments?.[0].content).toBe('');
+    expect(result?.attachments?.[0].filename).toBe('document.pdf');
+    expect(result?.attachments?.[0].encoding).toBe('base64');
+  });
+});

--- a/src/apps/chatwoot/consumers/waha/base.ts
+++ b/src/apps/chatwoot/consumers/waha/base.ts
@@ -329,7 +329,22 @@ export abstract class MessageBaseHandler<
       `Created message as '${message.message_type}' from WhatsApp: ${response.id}`,
     );
     await this.saveMapping(response, payload);
-    return message;
+    const sanitizedAttachments = message.attachments
+      ? message.attachments.map((attachment) => {
+          return {
+            content: '',
+            filename: attachment.filename,
+            encoding: attachment.encoding,
+          };
+        })
+      : undefined;
+    return {
+      content: message.content,
+      message_type: message.message_type,
+      private: message.private,
+      attachments: sanitizedAttachments,
+      content_attributes: message.content_attributes,
+    };
   }
 
   private async saveMapping(


### PR DESCRIPTION
## Summary

Fixes high Redis memory usage caused by storing full base64-encoded media attachments in BullMQ job `returnvalue` fields within the Chatwoot integration consumer.

---

## Problem

When a WhatsApp media message (e.g., a 150MB PDF or video) is processed by `WAHAMessageAnyConsumer`:
1. `MessageBaseHandler.handle()` calls `buildChatWootMessage()`, which reads the media file into a base64 string under `attachments[].content`.
2. After sending the payload to Chatwoot via `conversation.send(message)`, `handle()` returns `message` directly.
3. BullMQ serializes the return value of `processJob()` into Redis under `bull:chatwoot.waha:<jobId>` (`returnvalue`).
4. As a result, each processed media job retains **200MB+** of base64 data in Redis until cleaned up by retention policies (`REMOVE_ON_COMPLETE_AGE`/`COUNT`).

---

## Solution

Sanitize `attachments[].content` to an empty string (`''`) in the object returned by `handle()`.

- **Chatwoot API call (`conversation.send`):** Receives the full `message` object with valid base64 media content intact.
- **BullMQ return value stored in Redis:** Contains lightweight attachment metadata (`filename`, `encoding`) with empty `content`, reducing job footprint in Redis from hundreds of MBs to **~500 bytes**.

---

## Changes Included

- **`src/apps/chatwoot/consumers/waha/base.ts`**: Updated `MessageBaseHandler.handle()` return value to sanitize `attachments[].content`.
- **`src/apps/chatwoot/consumers/waha/base.test.ts`**: Added unit test verifying that `conversation.send()` receives the original base64 payload while the returned job result strips it.


## Tested

- `corepack yarn lint`
- `corepack yarn build`

---

## Verification

Ran unit tests locally:

```bash
npx jest --selectProjects unit src/apps/chatwoot/consumers/waha/base.test.ts
```

Output:
```
PASS unit src/apps/chatwoot/consumers/waha/base.test.ts
  MessageBaseHandler
    ✓ should sanitize attachment content to empty string on handle return
```
