### PR TITLE
[core] Fix NOWEB group leave webhook LID matching (#2206)

### DIFF
--- a/src/core/engines/noweb/groups.noweb.test.ts
+++ b/src/core/engines/noweb/groups.noweb.test.ts
@@ -1,0 +1,63 @@
+import { ToGroupV2LeaveEvent } from '@waha/core/engines/noweb/groups.noweb';
+
+describe('ToGroupV2LeaveEvent', () => {
+  const update = {
+    id: '120363422336768669@g.us',
+    author: '45848826278102@lid',
+    participants: [
+      {
+        id: '203732478357668@lid',
+        phoneNumber: '51966666666@s.whatsapp.net',
+        admin: null,
+      },
+    ],
+    action: 'remove',
+  };
+
+  it('emits leave when the removed participant matches me by lid', () => {
+    const event = ToGroupV2LeaveEvent(
+      {
+        id: '51966666666@s.whatsapp.net',
+        lid: '203732478357668@lid',
+      } as any,
+      update as any,
+    );
+
+    expect(event).toEqual({
+      timestamp: expect.any(Number),
+      group: {
+        id: '120363422336768669@g.us',
+      },
+      _data: update,
+    });
+  });
+
+  it('emits leave when the removed participant matches me by phone number', () => {
+    const event = ToGroupV2LeaveEvent(
+      {
+        id: '51966666666@s.whatsapp.net',
+      } as any,
+      update as any,
+    );
+
+    expect(event).toEqual({
+      timestamp: expect.any(Number),
+      group: {
+        id: '120363422336768669@g.us',
+      },
+      _data: update,
+    });
+  });
+
+  it('does not emit leave when another participant is removed', () => {
+    const event = ToGroupV2LeaveEvent(
+      {
+        id: '51900000000@s.whatsapp.net',
+        lid: '45848826278102@lid',
+      } as any,
+      update as any,
+    );
+
+    expect(event).toBeNull();
+  });
+});

--- a/src/core/engines/noweb/groups.noweb.ts
+++ b/src/core/engines/noweb/groups.noweb.ts
@@ -17,8 +17,7 @@ import {
   GroupV2ParticipantsEvent,
   GroupV2UpdateEvent,
 } from '@waha/structures/groups.events.dto';
-import { toCusFormat } from '@waha/core/utils/jids';
-import esm from '@waha/vendor/esm';
+import { normalizeJid, toCusFormat } from '@waha/core/utils/jids';
 
 export function ToGroupInfo(group: Partial<GroupMetadata>): GroupInfo {
   let participants: GroupParticipant[] = undefined;
@@ -75,6 +74,23 @@ function getParticipantId(
     return participant;
   }
   return participant?.id;
+}
+
+function getParticipantIds(
+  participant: string | NOWEBGroupParticipant,
+): string[] {
+  if (typeof participant === 'string') {
+    return [participant];
+  }
+  return [participant?.id, participant?.phoneNumber].filter(
+    (id): id is string => Boolean(id),
+  );
+}
+
+function getMeIds(me: Contact): string[] {
+  return [me?.id, me?.lid]
+    .filter((id): id is string => Boolean(id))
+    .map(normalizeJid);
 }
 
 export function ToGroupV2Participants(
@@ -140,10 +156,10 @@ export function ToGroupV2LeaveEvent(
   if (!me) {
     return null;
   }
-  const meId = esm.b.jidNormalizedUser(me.id);
+  const meIds = getMeIds(me);
   const includesMe = update.participants.some((participant) => {
-    const id = getParticipantId(participant);
-    return id === meId;
+    const participantIds = getParticipantIds(participant).map(normalizeJid);
+    return participantIds.some((id) => meIds.includes(id));
   });
   if (!includesMe) {
     return null;


### PR DESCRIPTION
Fixes NOWEB `group.v2.leave` not firing when Baileys reports the removed session participant by LID while the session identity is also available by phone JID.

- Match removed participants against both `me.id` and `me.lid`
- Consider both participant `id` and `phoneNumber`
- Add regression coverage for LID, phone-number, and non-self removals

Fixes #2206