### PR TITLE
fix(s3): set ContentType on uploaded media

### DIFF
--- a/src/core/media/IMediaStorage.ts
+++ b/src/core/media/IMediaStorage.ts
@@ -14,6 +14,7 @@ interface Message {
 interface File {
   extension: string;
   filename?: string;
+  mimetype?: string;
 }
 
 export interface MediaData {

--- a/src/core/media/MediaManager.ts
+++ b/src/core/media/MediaManager.ts
@@ -75,6 +75,7 @@ export class MediaManager implements IMediaManager {
       file: {
         extension: extension,
         filename: filename,
+        mimetype: mimetype,
       },
     };
 

--- a/src/core/media/s3/MediaS3Storage.ts
+++ b/src/core/media/s3/MediaS3Storage.ts
@@ -40,6 +40,7 @@ export class MediaS3Storage implements IMediaStorage {
       Bucket: this.bucket,
       Key: key,
       Body: buffer,
+      ContentType: data.file.mimetype,
       Metadata: metadata,
     });
     await this.client.send(command);


### PR DESCRIPTION
Media uploaded to S3 has no `ContentType`, so every object is stored as `application/octet-stream`. This change passes the message mimetype through to `PutObjectCommand`.