### PR TITLE
fix(proxy): honor HTTP(S)_PROXY when downloading media

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -18,9 +18,20 @@ import { SwaggerConfiguratorCore } from './core/SwaggerConfiguratorCore';
 import { AllExceptionsFilter } from './nestjs/AllExceptionsFilter';
 import { getWAHAVersion, VERSION, WAHAVersion } from './version';
 import { loadESMModules } from '@waha/vendor/esm';
-import { setGlobalDispatcher, Agent } from 'undici';
+import { setGlobalDispatcher, Agent, EnvHttpProxyAgent } from 'undici';
 
-setGlobalDispatcher(new Agent({ connect: { family: 4 } }));
+// fetch (media download) ignores HTTP(S)_PROXY unless the dispatcher handles it
+const proxyUrl =
+  process.env.https_proxy ||
+  process.env.HTTPS_PROXY ||
+  process.env.http_proxy ||
+  process.env.HTTP_PROXY;
+
+setGlobalDispatcher(
+  proxyUrl
+    ? new EnvHttpProxyAgent({ connect: { family: 4 } })
+    : new Agent({ connect: { family: 4 } }),
+);
 
 const logger: Logger = pino({
   level: getPinoLogLevel(),


### PR DESCRIPTION
## Problem

On a host with no direct internet egress, where all outbound HTTP(S) traffic has to go through a proxy, every incoming media message fails to download. The webhook is delivered with `hasMedia: true` and `media.url: null`, and the logs show:

```
MediaManager: fetch failed: Client network socket disconnected before secure TLS connection was established
  at getHttpStream (@adiwajshing/baileys/lib/Utils/messages-media.js:298)
  ... Failed to execute 'Fetching media', tried '5' times
```

`WHATSAPP_PROXY_SERVER` does not cover this: it builds an `HttpsProxyAgent` for the Baileys socket, while media is fetched through Node's global `fetch`, which uses undici and ignores that agent.

Node's `NODE_USE_ENV_PROXY=1` does not help either, because `src/main.ts` replaces the global dispatcher during bootstrap:

```ts
setGlobalDispatcher(new Agent({ connect: { family: 4 } }));
```

That call discards the proxy-aware dispatcher installed from the environment, so `fetch` goes out direct and fails.

## Fix

Keep the IPv4 pinning, but pick a proxy-aware dispatcher when proxy variables are present. `EnvHttpProxyAgent` (undici >= 6.20, and this repo is on ^7.16) reads `http_proxy`/`https_proxy` and honors `NO_PROXY`, so internal hosts such as S3 storage and webhook targets keep going direct.

With no proxy variables set, behavior is identical to today.

## Testing

Verified on a proxy-only network with the NOWEB engine: without the change every media download fails with the error above; with it, `MediaManager` logs `The media from '<id>' has been saved.` and the webhook carries a working `media.url`. S3 uploads to an internal endpoint listed in `NO_PROXY` still go direct.
