### PR TITLE
sendSticker route

### DIFF
--- a/src/api/chatting.controller.ts
+++ b/src/api/chatting.controller.ts
@@ -9,7 +9,7 @@ import {
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
-import { ApiOperation, ApiSecurity, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiOperation, ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { WAHAValidationPipe } from '@waha/nestjs/pipes/WAHAValidationPipe';
 import {
   GetChatMessagesFilter,
@@ -39,6 +39,7 @@ import {
   MessageStarRequest,
   MessageTextQuery,
   MessageTextRequest,
+  MessageStickerRequest,
   MessageVideoRequest,
   MessageVoiceRequest,
   NewMessageIDResponse,
@@ -143,6 +144,46 @@ export class ChattingController {
       request.mentions = await whatsapp.resolveMentionsAll(request.chatId);
     }
     return whatsapp.sendVideo(request);
+  }
+
+  @Post('/sendSticker')
+  @ApiOperation({
+    summary: 'Send a sticker',
+    description:
+      'Send a WebP image as a sticker. Either from an URL or base64 data. PNG and JPEG images are automatically converted to WebP.',
+  })
+  @ApiBody({
+    type: MessageStickerRequest,
+    examples: {
+      url: {
+        summary: 'From URL',
+        value: {
+          session: 'default',
+          chatId: '11111111111@c.us',
+          reply_to: null,
+          file: {
+            url: 'https://www.gstatic.com/webp/gallery/1.webp',
+          },
+        },
+      },
+      base64webp: {
+        summary: 'From base64 WebP',
+        value: {
+          session: 'default',
+          chatId: '11111111111@c.us',
+          reply_to: null,
+          file: {
+            mimetype: 'image/webp',
+            data: 'your-base64-data-of-webp',
+          },
+        },
+      },
+    },
+  })
+  @CheckPolicies(CanSession(Action.Send, FromBody('session')))
+  async sendSticker(@Body() request: MessageStickerRequest) {
+    const whatsapp = await this.manager.getWorkingSession(request.session);
+    return whatsapp.sendSticker(request);
   }
 
   @Post('/send/link-custom-preview')

--- a/src/api/chatting.controller.ts
+++ b/src/api/chatting.controller.ts
@@ -150,7 +150,7 @@ export class ChattingController {
   @ApiOperation({
     summary: 'Send a sticker',
     description:
-      'Send a WebP image as a sticker. Either from an URL or base64 data. PNG and JPEG images are automatically converted to WebP.',
+      'The image will not be converted. It must already be in WebP format. PNG and JPEG are not supported.',
   })
   @ApiBody({
     type: MessageStickerRequest,

--- a/src/core/abc/session.abc.ts
+++ b/src/core/abc/session.abc.ts
@@ -87,6 +87,7 @@ import {
   MessageReplyRequest,
   MessageStarRequest,
   MessageTextRequest,
+  MessageStickerRequest,
   MessageVideoRequest,
   MessageVoiceRequest,
   SendSeenRequest,
@@ -662,6 +663,10 @@ export abstract class WhatsappSession {
   abstract sendVoice(request: MessageVoiceRequest);
 
   sendVideo(request: MessageVideoRequest) {
+    throw new NotImplementedByEngineError();
+  }
+
+  sendSticker(request: MessageStickerRequest) {
     throw new NotImplementedByEngineError();
   }
 

--- a/src/core/engines/webjs/session.webjs.core.ts
+++ b/src/core/engines/webjs/session.webjs.core.ts
@@ -84,6 +84,7 @@ import {
   MessageReplyRequest,
   MessageStarRequest,
   MessageTextRequest,
+  MessageStickerRequest,
   MessageVideoRequest,
   SendSeenRequest,
   WANumberExistResult,
@@ -1129,6 +1130,17 @@ export class WhatsappSessionWebJSCore extends WhatsappSession {
       this.ensureSuffix(request.chatId),
       media,
       options,
+    );
+  }
+
+  @Activity()
+  async sendSticker(request: MessageStickerRequest) {
+    const media = await this.fileToMedia(request.file);
+    const options = this.getMessageOptions(request);
+    return this.whatsapp.sendMessage(
+      this.ensureSuffix(request.chatId),
+      media,
+      { ...options, sendMediaAsSticker: true },
     );
   }
 

--- a/src/structures/chatting.dto.ts
+++ b/src/structures/chatting.dto.ts
@@ -381,6 +381,11 @@ export class MessageVideoRequest extends ChatRequest {
   convert: boolean;
 }
 
+export class MessageStickerRequest extends FileRequest {
+  @ReplyToProperty()
+  reply_to?: string;
+}
+
 export class MessageLinkPreviewRequest extends ChatRequest {
   @GeneratedMessageIdProperty()
   id?: string;


### PR DESCRIPTION
First of all, a huge thank you to the WAHA team for making this project completely free and open source, with no payments or subscriptions required. It's an incredible tool that has helped many developers integrate WhatsApp into their applications without unnecessary friction or costs.

This PR adds the POST /sendSticker endpoint to the WEBJS engine, allowing users to send WebP images as WhatsApp stickers. The implementation follows the existing patterns in the codebase and includes:

New MessageStickerRequest DTO extending FileRequest (supports both URL and base64)
sendSticker method on the session abstract class
WEBJS engine implementation using sendMediaAsSticker: true
Swagger documentation with examples for URL and base64 WebP input