### PR TITLE
[core] feat: opt-in Prometheus GET /metrics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,9 @@ WAHA_LOG_LEVEL=info
 # Don't print QR codes in logs
 WAHA_PRINT_QR=False
 
+# Prometheus scrape endpoint GET /metrics (unauthenticated, same auth model as /ping)
+# WAHA_PROMETHEUS_ENABLED=false
+
 # =========================
 # ===== MEDIA STORAGE =====
 # =========================

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "pino-http": "^10.2.0",
     "pino-pretty": "^11.2.1",
     "pretty-bytes": "5.6.0",
+    "prom-client": "^15.1.3",
     "promise-retry": "^2.0.1",
     "puppeteer": "^24.31.0",
     "qrcode": "^1.5.1",

--- a/src/api/metrics.controller.test.ts
+++ b/src/api/metrics.controller.test.ts
@@ -1,0 +1,47 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+import { MetricsController } from '@waha/api/metrics.controller';
+import {
+  createWahaMetricsRegistry,
+  WAHA_METRICS_REGISTRY,
+} from '@waha/core/metrics/prometheus.registry';
+
+describe('MetricsController', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [MetricsController],
+      providers: [
+        {
+          provide: WAHA_METRICS_REGISTRY,
+          useFactory: createWahaMetricsRegistry,
+        },
+      ],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  afterEach(() => {
+    delete process.env.WAHA_PROMETHEUS_ENABLED;
+  });
+
+  test('returns 404 when disabled', async () => {
+    const response = await request(app.getHttpServer()).get('/metrics');
+    expect(response.status).toBe(404);
+  });
+
+  test('returns prometheus text when enabled', async () => {
+    process.env.WAHA_PROMETHEUS_ENABLED = 'true';
+    const response = await request(app.getHttpServer()).get('/metrics');
+    expect(response.status).toBe(200);
+    expect(response.header['content-type']).toMatch(/text\/plain/);
+    expect(response.text).toMatch(/waha_up(?:\{[^}]*\})? 1/);
+  });
+});

--- a/src/api/metrics.controller.test.ts
+++ b/src/api/metrics.controller.test.ts
@@ -3,6 +3,7 @@ import { Test } from '@nestjs/testing';
 import * as request from 'supertest';
 import { MetricsController } from '@waha/api/metrics.controller';
 import { WhatsappConfigService } from '@waha/config.service';
+import { SessionMetricsCollector } from '@waha/core/metrics/session.metrics';
 import { WahaMetrics } from '@waha/core/metrics/waha.metrics';
 
 describe('MetricsController', () => {
@@ -13,6 +14,10 @@ describe('MetricsController', () => {
         {
           provide: WahaMetrics,
           useValue: new WahaMetrics(enabled),
+        },
+        {
+          provide: SessionMetricsCollector,
+          useValue: { collect: async () => undefined },
         },
         {
           provide: WhatsappConfigService,

--- a/src/api/metrics.controller.test.ts
+++ b/src/api/metrics.controller.test.ts
@@ -2,46 +2,42 @@ import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import * as request from 'supertest';
 import { MetricsController } from '@waha/api/metrics.controller';
-import {
-  createWahaMetricsRegistry,
-  WAHA_METRICS_REGISTRY,
-} from '@waha/core/metrics/prometheus.registry';
+import { WhatsappConfigService } from '@waha/config.service';
+import { WahaMetrics } from '@waha/core/metrics/waha.metrics';
 
 describe('MetricsController', () => {
-  let app: INestApplication;
-
-  beforeAll(async () => {
+  async function buildApp(enabled: boolean): Promise<INestApplication> {
     const moduleRef = await Test.createTestingModule({
       controllers: [MetricsController],
       providers: [
         {
-          provide: WAHA_METRICS_REGISTRY,
-          useFactory: createWahaMetricsRegistry,
+          provide: WahaMetrics,
+          useValue: new WahaMetrics(enabled),
+        },
+        {
+          provide: WhatsappConfigService,
+          useValue: { prometheusEnabled: enabled },
         },
       ],
     }).compile();
-    app = moduleRef.createNestApplication();
+    const app = moduleRef.createNestApplication();
     await app.init();
-  });
+    return app;
+  }
 
-  afterAll(async () => {
+  test('returns 404 when disabled', async () => {
+    const app = await buildApp(false);
+    const response = await request(app.getHttpServer()).get('/metrics');
+    expect(response.status).toBe(404);
     await app.close();
   });
 
-  afterEach(() => {
-    delete process.env.WAHA_PROMETHEUS_ENABLED;
-  });
-
-  test('returns 404 when disabled', async () => {
-    const response = await request(app.getHttpServer()).get('/metrics');
-    expect(response.status).toBe(404);
-  });
-
   test('returns prometheus text when enabled', async () => {
-    process.env.WAHA_PROMETHEUS_ENABLED = 'true';
+    const app = await buildApp(true);
     const response = await request(app.getHttpServer()).get('/metrics');
     expect(response.status).toBe(200);
     expect(response.header['content-type']).toMatch(/text\/plain/);
     expect(response.text).toMatch(/waha_up(?:\{[^}]*\})? 1/);
+    await app.close();
   });
 });

--- a/src/api/metrics.controller.ts
+++ b/src/api/metrics.controller.ts
@@ -1,18 +1,12 @@
-import { Controller, Get, Header, Inject, Res } from '@nestjs/common';
+import { Controller, Get, Header, Res } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Response } from 'express';
-import { Registry } from 'prom-client';
-import {
-  prometheusEnabled,
-  WAHA_METRICS_REGISTRY,
-} from '@waha/core/metrics/prometheus.registry';
+import { WahaMetrics } from '@waha/core/metrics/waha.metrics';
 
 @Controller('metrics')
 @ApiTags('🔍 Observability')
 export class MetricsController {
-  constructor(
-    @Inject(WAHA_METRICS_REGISTRY) private readonly register: Registry,
-  ) {}
+  constructor(private readonly metrics: WahaMetrics) {}
 
   @Get()
   @Header('Cache-Control', 'no-store')
@@ -21,15 +15,15 @@ export class MetricsController {
     description:
       'Prometheus text exposition. Disabled by default (404). Set WAHA_PROMETHEUS_ENABLED=true. Unauthenticated so in-cluster scrapers can collect it.',
   })
-  async metrics(@Res() response: Response): Promise<void> {
-    if (!prometheusEnabled()) {
+  async metricsEndpoint(@Res() response: Response): Promise<void> {
+    if (!this.metrics.isEnabled) {
       response.status(404).send();
       return;
     }
-    const body = await this.register.metrics();
+    const body = await this.metrics.render();
     response
       .status(200)
-      .set('Content-Type', this.register.contentType)
+      .set('Content-Type', this.metrics.register.contentType)
       .send(body);
   }
 }

--- a/src/api/metrics.controller.ts
+++ b/src/api/metrics.controller.ts
@@ -1,0 +1,35 @@
+import { Controller, Get, Header, Inject, Res } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Response } from 'express';
+import { Registry } from 'prom-client';
+import {
+  prometheusEnabled,
+  WAHA_METRICS_REGISTRY,
+} from '@waha/core/metrics/prometheus.registry';
+
+@Controller('metrics')
+@ApiTags('🔍 Observability')
+export class MetricsController {
+  constructor(
+    @Inject(WAHA_METRICS_REGISTRY) private readonly register: Registry,
+  ) {}
+
+  @Get()
+  @Header('Cache-Control', 'no-store')
+  @ApiOperation({
+    summary: 'Prometheus metrics',
+    description:
+      'Prometheus text exposition. Disabled by default (404). Set WAHA_PROMETHEUS_ENABLED=true. Unauthenticated so in-cluster scrapers can collect it.',
+  })
+  async metrics(@Res() response: Response): Promise<void> {
+    if (!prometheusEnabled()) {
+      response.status(404).send();
+      return;
+    }
+    const body = await this.register.metrics();
+    response
+      .status(200)
+      .set('Content-Type', this.register.contentType)
+      .send(body);
+  }
+}

--- a/src/api/metrics.controller.ts
+++ b/src/api/metrics.controller.ts
@@ -1,12 +1,16 @@
 import { Controller, Get, Header, Res } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Response } from 'express';
+import { SessionMetricsCollector } from '@waha/core/metrics/session.metrics';
 import { WahaMetrics } from '@waha/core/metrics/waha.metrics';
 
 @Controller('metrics')
 @ApiTags('🔍 Observability')
 export class MetricsController {
-  constructor(private readonly metrics: WahaMetrics) {}
+  constructor(
+    private readonly metrics: WahaMetrics,
+    private readonly sessions: SessionMetricsCollector,
+  ) {}
 
   @Get()
   @Header('Cache-Control', 'no-store')
@@ -20,6 +24,7 @@ export class MetricsController {
       response.status(404).send();
       return;
     }
+    await this.sessions.collect();
     const body = await this.metrics.render();
     response
       .status(200)

--- a/src/config.service.test.ts
+++ b/src/config.service.test.ts
@@ -1,0 +1,32 @@
+import { ConfigService } from '@nestjs/config';
+import { WhatsappConfigService } from '@waha/config.service';
+
+function serviceWith(value: string | undefined): WhatsappConfigService {
+  const configService = {
+    get: (key: string, defaultValue?: string) => {
+      if (key === 'WAHA_PROMETHEUS_ENABLED') {
+        if (value === undefined) {
+          return defaultValue;
+        }
+        return value;
+      }
+      return defaultValue;
+    },
+  } as ConfigService;
+  return new WhatsappConfigService(configService);
+}
+
+describe('WhatsappConfigService.prometheusEnabled', () => {
+  test('defaults to false', () => {
+    expect(serviceWith(undefined).prometheusEnabled).toBe(false);
+    expect(serviceWith('').prometheusEnabled).toBe(false);
+    expect(serviceWith('false').prometheusEnabled).toBe(false);
+    expect(serviceWith('0').prometheusEnabled).toBe(false);
+  });
+
+  test('accepts true and 1', () => {
+    expect(serviceWith('true').prometheusEnabled).toBe(true);
+    expect(serviceWith('1').prometheusEnabled).toBe(true);
+    expect(serviceWith('TRUE').prometheusEnabled).toBe(true);
+  });
+});

--- a/src/config.service.ts
+++ b/src/config.service.ts
@@ -182,6 +182,11 @@ export class WhatsappConfigService implements OnApplicationBootstrap {
     return parseBool(value);
   }
 
+  get prometheusEnabled(): boolean {
+    const value = this.configService.get('WAHA_PROMETHEUS_ENABLED', 'false');
+    return parseBool(value);
+  }
+
   /**
    * Global default "ignore settings" for chats.
    * If not defined, defaults to false (do not ignore anything).

--- a/src/core/SwaggerConfiguratorCore.ts
+++ b/src/core/SwaggerConfiguratorCore.ts
@@ -1,9 +1,9 @@
 import { INestApplication } from '@nestjs/common';
-import * as lodash from 'lodash';
 import { DocumentBuilder, OpenAPIObject, SwaggerModule } from '@nestjs/swagger';
 import { DECORATORS } from '@nestjs/swagger/dist/constants';
 import { BasicAuthFunction } from '@waha/core/auth/basicAuth';
 import { DashboardConfigServiceCore } from '@waha/core/config/DashboardConfigServiceCore';
+import { swaggerBasicAuthExcludePaths } from '@waha/core/metrics/swagger-auth.exclude';
 import { Logger } from 'nestjs-pino';
 
 import { WhatsappConfigService } from '../config.service';
@@ -188,18 +188,10 @@ export class SwaggerConfiguratorCore {
     const [username, password] = credentials;
     const dashboardConfig = this.app.get(DashboardConfigServiceCore);
     const config = this.app.get(WhatsappConfigService);
-    const exclude = lodash.uniq([
-      '/api/',
-      '/mcp',
+    const exclude = swaggerBasicAuthExcludePaths(
       dashboardConfig.dashboardUri,
-      '/health',
-      '/ping',
-      '/ws',
-      '/webhooks/',
-      '/jobs',
-      '/jobs/',
-      ...config.getExcludedFullPaths(),
-    ]);
+      config.getExcludedFullPaths(),
+    );
 
     const authFunction = BasicAuthFunction(username, password, exclude);
     this.app.use(authFunction);

--- a/src/core/app.module.core.ts
+++ b/src/core/app.module.core.ts
@@ -58,7 +58,12 @@ import { GroupsController } from '../api/groups.controller';
 import { HealthController } from '../api/health.controller';
 import { LabelsController } from '../api/labels.controller';
 import { MediaController } from '../api/media.controller';
+import { MetricsController } from '../api/metrics.controller';
 import { PingController } from '../api/ping.controller';
+import {
+  createWahaMetricsRegistry,
+  WAHA_METRICS_REGISTRY,
+} from '@waha/core/metrics/prometheus.registry';
 import { PresenceController } from '../api/presence.controller';
 import { ScreenshotController } from '../api/screenshot.controller';
 import { SessionsController } from '../api/sessions.controller';
@@ -91,6 +96,7 @@ export const IMPORTS_CORE = [
         ignore: (req) => {
           return (
             req.url.startsWith('/ping') ||
+            req.url.startsWith('/metrics') ||
             req.url.startsWith('/dashboard/') ||
             req.url.startsWith('/api/files/') ||
             req.url.startsWith('/api/s3/') ||
@@ -189,6 +195,7 @@ export const CONTROLLERS = [
   ScreenshotController,
   EventsController,
   PingController,
+  MetricsController,
   HealthController,
   ServerController,
   ServerDebugController,
@@ -219,6 +226,10 @@ export const PROVIDERS_BASE: Provider[] = [
   CaslAbilityFactory,
   PoliciesGuard,
   SessionService,
+  {
+    provide: WAHA_METRICS_REGISTRY,
+    useFactory: createWahaMetricsRegistry,
+  },
   {
     provide: IApiKeyAuth,
     useFactory: ApiKeyAuthFactory,

--- a/src/core/app.module.core.ts
+++ b/src/core/app.module.core.ts
@@ -60,6 +60,7 @@ import { LabelsController } from '../api/labels.controller';
 import { MediaController } from '../api/media.controller';
 import { MetricsController } from '../api/metrics.controller';
 import { PingController } from '../api/ping.controller';
+import { HttpMetricsMiddleware } from '@waha/core/metrics/http.metrics.middleware';
 import { WahaMetrics } from '@waha/core/metrics/waha.metrics';
 import { PresenceController } from '../api/presence.controller';
 import { ScreenshotController } from '../api/screenshot.controller';
@@ -230,6 +231,7 @@ export const PROVIDERS_BASE: Provider[] = [
     },
     inject: [WhatsappConfigService],
   },
+  HttpMetricsMiddleware,
   {
     provide: IApiKeyAuth,
     useFactory: ApiKeyAuthFactory,
@@ -286,6 +288,8 @@ export class AppModuleCore {
   }
 
   configure(consumer: MiddlewareConsumer) {
+    consumer.apply(HttpMetricsMiddleware).forRoutes('*');
+
     // Because we use ServeStaticModule, we need to inject a middleware
     // ServeStaticModule does not support @UseGuards
     const exclude = this.config.getExcludedPaths();

--- a/src/core/app.module.core.ts
+++ b/src/core/app.module.core.ts
@@ -61,6 +61,7 @@ import { MediaController } from '../api/media.controller';
 import { MetricsController } from '../api/metrics.controller';
 import { PingController } from '../api/ping.controller';
 import { HttpMetricsMiddleware } from '@waha/core/metrics/http.metrics.middleware';
+import { MessageMetricsSubscriber } from '@waha/core/metrics/message.metrics';
 import { SessionMetricsCollector } from '@waha/core/metrics/session.metrics';
 import { WahaMetrics } from '@waha/core/metrics/waha.metrics';
 import { PresenceController } from '../api/presence.controller';
@@ -233,6 +234,7 @@ export const PROVIDERS_BASE: Provider[] = [
     inject: [WhatsappConfigService],
   },
   HttpMetricsMiddleware,
+  MessageMetricsSubscriber,
   SessionMetricsCollector,
   {
     provide: IApiKeyAuth,

--- a/src/core/app.module.core.ts
+++ b/src/core/app.module.core.ts
@@ -61,6 +61,7 @@ import { MediaController } from '../api/media.controller';
 import { MetricsController } from '../api/metrics.controller';
 import { PingController } from '../api/ping.controller';
 import { HttpMetricsMiddleware } from '@waha/core/metrics/http.metrics.middleware';
+import { SessionMetricsCollector } from '@waha/core/metrics/session.metrics';
 import { WahaMetrics } from '@waha/core/metrics/waha.metrics';
 import { PresenceController } from '../api/presence.controller';
 import { ScreenshotController } from '../api/screenshot.controller';
@@ -232,6 +233,7 @@ export const PROVIDERS_BASE: Provider[] = [
     inject: [WhatsappConfigService],
   },
   HttpMetricsMiddleware,
+  SessionMetricsCollector,
   {
     provide: IApiKeyAuth,
     useFactory: ApiKeyAuthFactory,

--- a/src/core/app.module.core.ts
+++ b/src/core/app.module.core.ts
@@ -60,10 +60,7 @@ import { LabelsController } from '../api/labels.controller';
 import { MediaController } from '../api/media.controller';
 import { MetricsController } from '../api/metrics.controller';
 import { PingController } from '../api/ping.controller';
-import {
-  createWahaMetricsRegistry,
-  WAHA_METRICS_REGISTRY,
-} from '@waha/core/metrics/prometheus.registry';
+import { WahaMetrics } from '@waha/core/metrics/waha.metrics';
 import { PresenceController } from '../api/presence.controller';
 import { ScreenshotController } from '../api/screenshot.controller';
 import { SessionsController } from '../api/sessions.controller';
@@ -227,8 +224,11 @@ export const PROVIDERS_BASE: Provider[] = [
   PoliciesGuard,
   SessionService,
   {
-    provide: WAHA_METRICS_REGISTRY,
-    useFactory: createWahaMetricsRegistry,
+    provide: WahaMetrics,
+    useFactory: (config: WhatsappConfigService) => {
+      return new WahaMetrics(config.prometheusEnabled);
+    },
+    inject: [WhatsappConfigService],
   },
   {
     provide: IApiKeyAuth,

--- a/src/core/metrics/http.metrics.middleware.test.ts
+++ b/src/core/metrics/http.metrics.middleware.test.ts
@@ -1,0 +1,55 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+import { Controller, Get } from '@nestjs/common';
+import { HttpMetricsMiddleware } from '@waha/core/metrics/http.metrics.middleware';
+import { WahaMetrics } from '@waha/core/metrics/waha.metrics';
+
+@Controller()
+class ProbeController {
+  @Get('ping')
+  ping(): string {
+    return 'pong';
+  }
+
+  @Get('metrics')
+  metrics(): string {
+    return 'scrape';
+  }
+}
+
+describe('HttpMetricsMiddleware', () => {
+  let app: INestApplication;
+  let metrics: WahaMetrics;
+
+  beforeAll(async () => {
+    metrics = new WahaMetrics(true);
+    const moduleRef = await Test.createTestingModule({
+      controllers: [ProbeController],
+      providers: [
+        {
+          provide: WahaMetrics,
+          useValue: metrics,
+        },
+        HttpMetricsMiddleware,
+      ],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    const middleware = app.get(HttpMetricsMiddleware);
+    app.use(middleware.use.bind(middleware));
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  test('records ping and ignores metrics path', async () => {
+    await request(app.getHttpServer()).get('/ping').expect(200);
+    await request(app.getHttpServer()).get('/metrics').expect(200);
+    const body = await metrics.render();
+    expect(body).toMatch(
+      /waha_http_requests_total\{method="GET",status="200"\} 1/,
+    );
+  });
+});

--- a/src/core/metrics/http.metrics.middleware.ts
+++ b/src/core/metrics/http.metrics.middleware.ts
@@ -1,0 +1,27 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { NextFunction, Request, Response } from 'express';
+import { isMetricsPath } from '@waha/core/metrics/prometheus.registry';
+import { WahaMetrics } from '@waha/core/metrics/waha.metrics';
+
+@Injectable()
+export class HttpMetricsMiddleware implements NestMiddleware {
+  constructor(private readonly metrics: WahaMetrics) {}
+
+  use(req: Request, res: Response, next: NextFunction): void {
+    if (!this.metrics.isEnabled) {
+      next();
+      return;
+    }
+    const start = process.hrtime.bigint();
+    res.on('finish', () => {
+      const path = req.path || req.url || '';
+      if (isMetricsPath(path)) {
+        return;
+      }
+      const end = process.hrtime.bigint();
+      const durationSeconds = Number(end - start) / 1e9;
+      this.metrics.observeHttpRequest(req.method, res.statusCode, durationSeconds);
+    });
+    next();
+  }
+}

--- a/src/core/metrics/message.metrics.test.ts
+++ b/src/core/metrics/message.metrics.test.ts
@@ -1,0 +1,48 @@
+import { Subject } from 'rxjs';
+import { WAHAEvents } from '@waha/structures/enums.dto';
+import {
+  messageDirection,
+  MessageMetricsSubscriber,
+} from '@waha/core/metrics/message.metrics';
+import { WahaMetrics } from '@waha/core/metrics/waha.metrics';
+
+describe('messageDirection', () => {
+  test('reads wrapped payload.fromMe', () => {
+    expect(messageDirection({ payload: { fromMe: true } })).toBe('out');
+    expect(messageDirection({ payload: { fromMe: false } })).toBe('in');
+  });
+
+  test('reads raw fromMe', () => {
+    expect(messageDirection({ fromMe: true })).toBe('out');
+    expect(messageDirection({ fromMe: false })).toBe('in');
+  });
+
+  test('skips unknown shapes', () => {
+    expect(messageDirection(null)).toBeNull();
+    expect(messageDirection({})).toBeNull();
+    expect(messageDirection({ payload: {} })).toBeNull();
+  });
+});
+
+describe('MessageMetricsSubscriber', () => {
+  test('increments on MESSAGE_ANY and ignores bad events', async () => {
+    const metrics = new WahaMetrics(true);
+    const subject = new Subject<unknown>();
+    const manager = {
+      getSessionEvent: (session: string, event: WAHAEvents) => {
+        expect(session).toBe('*');
+        expect(event).toBe(WAHAEvents.MESSAGE_ANY);
+        return subject.asObservable();
+      },
+    };
+    const subscriber = new MessageMetricsSubscriber(metrics, manager as any);
+    subscriber.onModuleInit();
+    subject.next({ payload: { fromMe: false } });
+    subject.next({ payload: { fromMe: true } });
+    subject.next({ payload: {} });
+    const body = await metrics.render();
+    expect(body).toContain('waha_messages_total{direction="in"} 1');
+    expect(body).toContain('waha_messages_total{direction="out"} 1');
+    subscriber.onModuleDestroy();
+  });
+});

--- a/src/core/metrics/message.metrics.ts
+++ b/src/core/metrics/message.metrics.ts
@@ -1,0 +1,69 @@
+import {
+  Injectable,
+  OnModuleDestroy,
+  OnModuleInit,
+} from '@nestjs/common';
+import { SessionManager } from '@waha/core/abc/manager.abc';
+import {
+  MessageDirection,
+  WahaMetrics,
+} from '@waha/core/metrics/waha.metrics';
+import { WAHAEvents } from '@waha/structures/enums.dto';
+import { Subscription } from 'rxjs';
+
+export function messageDirection(event: unknown): MessageDirection | null {
+  if (event === null || typeof event !== 'object') {
+    return null;
+  }
+  const record = event as {
+    fromMe?: unknown;
+    payload?: { fromMe?: unknown };
+  };
+  let fromMe: unknown = record.fromMe;
+  if (typeof fromMe !== 'boolean') {
+    const payload = record.payload;
+    if (payload && typeof payload === 'object') {
+      fromMe = payload.fromMe;
+    }
+  }
+  if (fromMe === true) {
+    return 'out';
+  }
+  if (fromMe === false) {
+    return 'in';
+  }
+  return null;
+}
+
+@Injectable()
+export class MessageMetricsSubscriber implements OnModuleInit, OnModuleDestroy {
+  private subscription: Subscription | null = null;
+
+  constructor(
+    private readonly metrics: WahaMetrics,
+    private readonly manager: SessionManager,
+  ) {}
+
+  onModuleInit(): void {
+    if (!this.metrics.isEnabled) {
+      return;
+    }
+    this.subscription = this.manager
+      .getSessionEvent('*', WAHAEvents.MESSAGE_ANY)
+      .subscribe((event: unknown) => {
+        const direction = messageDirection(event);
+        if (!direction) {
+          return;
+        }
+        this.metrics.observeMessage(direction);
+      });
+  }
+
+  onModuleDestroy(): void {
+    if (!this.subscription) {
+      return;
+    }
+    this.subscription.unsubscribe();
+    this.subscription = null;
+  }
+}

--- a/src/core/metrics/prometheus.registry.test.ts
+++ b/src/core/metrics/prometheus.registry.test.ts
@@ -1,32 +1,16 @@
 import {
-  createWahaMetricsRegistry,
-  parsePrometheusFlag,
+  isMetricsPath,
+  WAHA_METRICS_PATH,
+  WAHA_METRICS_PREFIX,
 } from '@waha/core/metrics/prometheus.registry';
 
-describe('parsePrometheusFlag', () => {
-  test('defaults to false', () => {
-    expect(parsePrometheusFlag(undefined)).toBe(false);
-    expect(parsePrometheusFlag('')).toBe(false);
-  });
-
-  test('accepts true and 1', () => {
-    expect(parsePrometheusFlag('true')).toBe(true);
-    expect(parsePrometheusFlag('1')).toBe(true);
-    expect(parsePrometheusFlag('TRUE')).toBe(true);
-  });
-
-  test('rejects other values', () => {
-    expect(parsePrometheusFlag('false')).toBe(false);
-    expect(parsePrometheusFlag('0')).toBe(false);
-    expect(parsePrometheusFlag('yes')).toBe(false);
-  });
-});
-
-describe('createWahaMetricsRegistry', () => {
-  test('exposes waha_up and default process metrics', async () => {
-    const register = createWahaMetricsRegistry();
-    const body = await register.metrics();
-    expect(body).toMatch(/waha_up(?:\{[^}]*\})? 1/);
-    expect(body).toContain('waha_process_cpu_user_seconds_total');
+describe('isMetricsPath', () => {
+  test('matches the scrape path', () => {
+    expect(WAHA_METRICS_PATH).toBe('/metrics');
+    expect(WAHA_METRICS_PREFIX).toBe('waha_');
+    expect(isMetricsPath('/metrics')).toBe(true);
+    expect(isMetricsPath('/metrics?foo=1')).toBe(true);
+    expect(isMetricsPath('/ping')).toBe(false);
+    expect(isMetricsPath('/api/sessions')).toBe(false);
   });
 });

--- a/src/core/metrics/prometheus.registry.test.ts
+++ b/src/core/metrics/prometheus.registry.test.ts
@@ -1,0 +1,32 @@
+import {
+  createWahaMetricsRegistry,
+  parsePrometheusFlag,
+} from '@waha/core/metrics/prometheus.registry';
+
+describe('parsePrometheusFlag', () => {
+  test('defaults to false', () => {
+    expect(parsePrometheusFlag(undefined)).toBe(false);
+    expect(parsePrometheusFlag('')).toBe(false);
+  });
+
+  test('accepts true and 1', () => {
+    expect(parsePrometheusFlag('true')).toBe(true);
+    expect(parsePrometheusFlag('1')).toBe(true);
+    expect(parsePrometheusFlag('TRUE')).toBe(true);
+  });
+
+  test('rejects other values', () => {
+    expect(parsePrometheusFlag('false')).toBe(false);
+    expect(parsePrometheusFlag('0')).toBe(false);
+    expect(parsePrometheusFlag('yes')).toBe(false);
+  });
+});
+
+describe('createWahaMetricsRegistry', () => {
+  test('exposes waha_up and default process metrics', async () => {
+    const register = createWahaMetricsRegistry();
+    const body = await register.metrics();
+    expect(body).toMatch(/waha_up(?:\{[^}]*\})? 1/);
+    expect(body).toContain('waha_process_cpu_user_seconds_total');
+  });
+});

--- a/src/core/metrics/prometheus.registry.ts
+++ b/src/core/metrics/prometheus.registry.ts
@@ -1,36 +1,16 @@
-import { Gauge, Registry, collectDefaultMetrics } from 'prom-client';
+export const WAHA_METRICS_PATH = '/metrics';
+export const WAHA_METRICS_PREFIX = 'waha_';
+export const WAHA_HTTP_DURATION_BUCKETS = [
+  0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30,
+];
 
-export const WAHA_METRICS_REGISTRY = 'WAHA_METRICS_REGISTRY';
-
-export function prometheusEnabled(): boolean {
-  return parsePrometheusFlag(process.env.WAHA_PROMETHEUS_ENABLED);
-}
-
-export function parsePrometheusFlag(value: string | undefined): boolean {
-  if (value === undefined || value === '') {
+export function isMetricsPath(path: string): boolean {
+  if (!path) {
     return false;
   }
-  const lowered = value.toLowerCase();
-  if (lowered === 'true' || lowered === '1') {
-    return true;
-  }
-  if (lowered === 'false' || lowered === '0') {
-    return false;
-  }
-  return false;
-}
-
-export function createWahaMetricsRegistry(): Registry {
-  const register = new Registry();
-  collectDefaultMetrics({
-    register: register,
-    prefix: 'waha_',
-  });
-  const up = new Gauge({
-    name: 'waha_up',
-    help: '1 if the WAHA process is serving Prometheus metrics',
-    registers: [register],
-  });
-  up.set(1);
-  return register;
+  const pathname = path.split('?')[0];
+  return (
+    pathname === WAHA_METRICS_PATH ||
+    pathname.startsWith(`${WAHA_METRICS_PATH}/`)
+  );
 }

--- a/src/core/metrics/prometheus.registry.ts
+++ b/src/core/metrics/prometheus.registry.ts
@@ -1,0 +1,36 @@
+import { Gauge, Registry, collectDefaultMetrics } from 'prom-client';
+
+export const WAHA_METRICS_REGISTRY = 'WAHA_METRICS_REGISTRY';
+
+export function prometheusEnabled(): boolean {
+  return parsePrometheusFlag(process.env.WAHA_PROMETHEUS_ENABLED);
+}
+
+export function parsePrometheusFlag(value: string | undefined): boolean {
+  if (value === undefined || value === '') {
+    return false;
+  }
+  const lowered = value.toLowerCase();
+  if (lowered === 'true' || lowered === '1') {
+    return true;
+  }
+  if (lowered === 'false' || lowered === '0') {
+    return false;
+  }
+  return false;
+}
+
+export function createWahaMetricsRegistry(): Registry {
+  const register = new Registry();
+  collectDefaultMetrics({
+    register: register,
+    prefix: 'waha_',
+  });
+  const up = new Gauge({
+    name: 'waha_up',
+    help: '1 if the WAHA process is serving Prometheus metrics',
+    registers: [register],
+  });
+  up.set(1);
+  return register;
+}

--- a/src/core/metrics/session.metrics.test.ts
+++ b/src/core/metrics/session.metrics.test.ts
@@ -1,0 +1,46 @@
+import { WAHAEngine, WAHASessionStatus } from '@waha/structures/enums.dto';
+import { SessionMetricsCollector } from '@waha/core/metrics/session.metrics';
+import { WahaMetrics } from '@waha/core/metrics/waha.metrics';
+
+describe('SessionMetricsCollector', () => {
+  test('collects runtime sessions without chatId labels', async () => {
+    const metrics = new WahaMetrics(true);
+    const manager = {
+      getSessions: async () => [
+        { name: 'default', status: WAHASessionStatus.WORKING },
+        { name: 'other', status: WAHASessionStatus.SCAN_QR_CODE },
+      ],
+      getSession: (name: string) => {
+        if (name === 'default') {
+          return { engine: WAHAEngine.GOWS };
+        }
+        return { engine: WAHAEngine.WEBJS };
+      },
+    };
+    const collector = new SessionMetricsCollector(metrics, manager as any);
+    await collector.collect();
+    const body = await metrics.render();
+    expect(body).toContain(
+      'waha_sessions{status="WORKING",engine="GOWS"} 1',
+    );
+    expect(body).toContain(
+      'waha_sessions{status="SCAN_QR_CODE",engine="WEBJS"} 1',
+    );
+    expect(body).not.toContain('default');
+    expect(body).not.toContain('chatId');
+  });
+
+  test('swallows getSessions failures', async () => {
+    const metrics = new WahaMetrics(true);
+    const manager = {
+      getSessions: async () => {
+        throw new Error('db down');
+      },
+      getSession: () => {
+        throw new Error('unused');
+      },
+    };
+    const collector = new SessionMetricsCollector(metrics, manager as any);
+    await expect(collector.collect()).resolves.toBeUndefined();
+  });
+});

--- a/src/core/metrics/session.metrics.ts
+++ b/src/core/metrics/session.metrics.ts
@@ -1,0 +1,47 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SessionManager } from '@waha/core/abc/manager.abc';
+import { SessionCountRow, WahaMetrics } from '@waha/core/metrics/waha.metrics';
+import { getEngineName } from '@waha/version';
+
+@Injectable()
+export class SessionMetricsCollector {
+  private readonly logger = new Logger(SessionMetricsCollector.name);
+
+  constructor(
+    private readonly metrics: WahaMetrics,
+    private readonly manager: SessionManager,
+  ) {}
+
+  async collect(): Promise<void> {
+    if (!this.metrics.isEnabled) {
+      return;
+    }
+    try {
+      const sessions = await this.manager.getSessions(false);
+      const rows: SessionCountRow[] = [];
+      for (const info of sessions) {
+        let engine = '';
+        try {
+          const session = this.manager.getSession(info.name);
+          if (session.engine) {
+            engine = String(session.engine);
+          }
+        } catch (error) {
+          this.logger.debug(
+            `Could not read engine for session metrics: ${error}`,
+          );
+        }
+        if (!engine) {
+          engine = getEngineName();
+        }
+        rows.push({
+          status: String(info.status),
+          engine: engine,
+        });
+      }
+      this.metrics.setSessionCounts(rows);
+    } catch (error) {
+      this.logger.warn(`Failed to collect session metrics: ${error}`);
+    }
+  }
+}

--- a/src/core/metrics/swagger-auth.exclude.test.ts
+++ b/src/core/metrics/swagger-auth.exclude.test.ts
@@ -1,0 +1,12 @@
+import { swaggerBasicAuthExcludePaths } from '@waha/core/metrics/swagger-auth.exclude';
+
+describe('swaggerBasicAuthExcludePaths', () => {
+  test('keeps ping and metrics public', () => {
+    const paths = swaggerBasicAuthExcludePaths('/dashboard', ['/custom']);
+    expect(paths).toContain('/ping');
+    expect(paths).toContain('/metrics');
+    expect(paths).toContain('/jobs');
+    expect(paths).toContain('/custom');
+    expect(paths).toContain('/dashboard');
+  });
+});

--- a/src/core/metrics/swagger-auth.exclude.ts
+++ b/src/core/metrics/swagger-auth.exclude.ts
@@ -1,0 +1,21 @@
+import * as lodash from 'lodash';
+import { WAHA_METRICS_PATH } from '@waha/core/metrics/prometheus.registry';
+
+export function swaggerBasicAuthExcludePaths(
+  dashboardUri: string,
+  extraFullPaths: string[],
+): string[] {
+  return lodash.uniq([
+    '/api/',
+    '/mcp',
+    dashboardUri,
+    '/health',
+    '/ping',
+    WAHA_METRICS_PATH,
+    '/ws',
+    '/webhooks/',
+    '/jobs',
+    '/jobs/',
+    ...extraFullPaths,
+  ]);
+}

--- a/src/core/metrics/waha.metrics.test.ts
+++ b/src/core/metrics/waha.metrics.test.ts
@@ -34,4 +34,20 @@ describe('WahaMetrics', () => {
     const body = await metrics.render();
     expect(body).not.toContain('waha_http_requests_total');
   });
+
+  test('setSessionCounts writes status and engine labels and resets', async () => {
+    const metrics = new WahaMetrics(true);
+    metrics.setSessionCounts([
+      { status: 'WORKING', engine: 'GOWS' },
+      { status: 'WORKING', engine: 'GOWS' },
+      { status: 'FAILED', engine: 'WEBJS' },
+    ]);
+    let body = await metrics.render();
+    expect(body).toContain('waha_sessions{status="WORKING",engine="GOWS"} 2');
+    expect(body).toContain('waha_sessions{status="FAILED",engine="WEBJS"} 1');
+    metrics.setSessionCounts([{ status: 'WORKING', engine: 'GOWS' }]);
+    body = await metrics.render();
+    expect(body).toContain('waha_sessions{status="WORKING",engine="GOWS"} 1');
+    expect(body).not.toContain('waha_sessions{status="FAILED",engine="WEBJS"}');
+  });
 });

--- a/src/core/metrics/waha.metrics.test.ts
+++ b/src/core/metrics/waha.metrics.test.ts
@@ -15,4 +15,23 @@ describe('WahaMetrics', () => {
     const body = await metrics.render();
     expect(body).not.toMatch(/waha_up(?:\{[^}]*\})? 1/);
   });
+
+  test('observeHttpRequest increments counter and histogram without path labels', async () => {
+    const metrics = new WahaMetrics(true);
+    metrics.observeHttpRequest('get', 200, 0.02);
+    metrics.observeHttpRequest('POST', 500, 0.4);
+    const body = await metrics.render();
+    expect(body).toContain('waha_http_requests_total{method="GET",status="200"} 1');
+    expect(body).toContain('waha_http_requests_total{method="POST",status="500"} 1');
+    expect(body).toContain('waha_http_request_duration_seconds_bucket');
+    expect(body).not.toContain('chatId');
+    expect(body).not.toContain('path=');
+  });
+
+  test('observeHttpRequest is a no-op when disabled', async () => {
+    const metrics = new WahaMetrics(false);
+    metrics.observeHttpRequest('GET', 200, 0.01);
+    const body = await metrics.render();
+    expect(body).not.toContain('waha_http_requests_total');
+  });
 });

--- a/src/core/metrics/waha.metrics.test.ts
+++ b/src/core/metrics/waha.metrics.test.ts
@@ -1,0 +1,18 @@
+import { WahaMetrics } from '@waha/core/metrics/waha.metrics';
+
+describe('WahaMetrics', () => {
+  test('when enabled exposes waha_up and process cpu', async () => {
+    const metrics = new WahaMetrics(true);
+    expect(metrics.isEnabled).toBe(true);
+    const body = await metrics.render();
+    expect(body).toMatch(/waha_up(?:\{[^}]*\})? 1/);
+    expect(body).toContain('waha_process_cpu_user_seconds_total');
+  });
+
+  test('when disabled does not expose waha_up', async () => {
+    const metrics = new WahaMetrics(false);
+    expect(metrics.isEnabled).toBe(false);
+    const body = await metrics.render();
+    expect(body).not.toMatch(/waha_up(?:\{[^}]*\})? 1/);
+  });
+});

--- a/src/core/metrics/waha.metrics.test.ts
+++ b/src/core/metrics/waha.metrics.test.ts
@@ -50,4 +50,15 @@ describe('WahaMetrics', () => {
     expect(body).toContain('waha_sessions{status="WORKING",engine="GOWS"} 1');
     expect(body).not.toContain('waha_sessions{status="FAILED",engine="WEBJS"}');
   });
+
+  test('observeMessage counts in and out only', async () => {
+    const metrics = new WahaMetrics(true);
+    metrics.observeMessage('in');
+    metrics.observeMessage('in');
+    metrics.observeMessage('out');
+    const body = await metrics.render();
+    expect(body).toContain('waha_messages_total{direction="in"} 2');
+    expect(body).toContain('waha_messages_total{direction="out"} 1');
+    expect(body).not.toContain('chatId');
+  });
 });

--- a/src/core/metrics/waha.metrics.ts
+++ b/src/core/metrics/waha.metrics.ts
@@ -1,0 +1,132 @@
+import {
+  Counter,
+  Gauge,
+  Histogram,
+  Registry,
+  collectDefaultMetrics,
+} from 'prom-client';
+import {
+  WAHA_HTTP_DURATION_BUCKETS,
+  WAHA_METRICS_PREFIX,
+} from '@waha/core/metrics/prometheus.registry';
+
+export type MessageDirection = 'in' | 'out';
+
+export interface SessionCountRow {
+  status: string;
+  engine: string;
+}
+
+export class WahaMetrics {
+  readonly register: Registry;
+  private readonly enabled: boolean;
+  private readonly httpRequests: Counter | null;
+  private readonly httpDuration: Histogram | null;
+  private readonly sessions: Gauge | null;
+  private readonly messages: Counter | null;
+
+  constructor(enabled: boolean) {
+    this.enabled = enabled;
+    this.register = new Registry();
+    if (!enabled) {
+      this.httpRequests = null;
+      this.httpDuration = null;
+      this.sessions = null;
+      this.messages = null;
+      return;
+    }
+    collectDefaultMetrics({
+      register: this.register,
+      prefix: WAHA_METRICS_PREFIX,
+    });
+    const up = new Gauge({
+      name: 'waha_up',
+      help: '1 if the WAHA process is serving Prometheus metrics',
+      registers: [this.register],
+    });
+    up.set(1);
+    this.httpRequests = new Counter({
+      name: 'waha_http_requests_total',
+      help: 'HTTP requests handled by WAHA',
+      labelNames: ['method', 'status'],
+      registers: [this.register],
+    });
+    this.httpDuration = new Histogram({
+      name: 'waha_http_request_duration_seconds',
+      help: 'HTTP request duration in seconds',
+      labelNames: ['method', 'status'],
+      buckets: WAHA_HTTP_DURATION_BUCKETS,
+      registers: [this.register],
+    });
+    this.sessions = new Gauge({
+      name: 'waha_sessions',
+      help: 'WhatsApp sessions by status and engine',
+      labelNames: ['status', 'engine'],
+      registers: [this.register],
+    });
+    this.messages = new Counter({
+      name: 'waha_messages_total',
+      help: 'WhatsApp messages observed by WAHA',
+      labelNames: ['direction'],
+      registers: [this.register],
+    });
+  }
+
+  get isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  observeHttpRequest(
+    method: string,
+    statusCode: number,
+    durationSeconds: number,
+  ): void {
+    if (!this.httpRequests || !this.httpDuration) {
+      return;
+    }
+    const labels = {
+      method: method.toUpperCase(),
+      status: String(statusCode),
+    };
+    this.httpRequests.inc(labels);
+    this.httpDuration.observe(labels, durationSeconds);
+  }
+
+  setSessionCounts(rows: SessionCountRow[]): void {
+    if (!this.sessions) {
+      return;
+    }
+    this.sessions.reset();
+    const counts = new Map<string, { status: string; engine: string; count: number }>();
+    for (const row of rows) {
+      const key = `${row.status}\0${row.engine}`;
+      const previous = counts.get(key);
+      if (previous) {
+        previous.count += 1;
+      } else {
+        counts.set(key, {
+          status: row.status,
+          engine: row.engine,
+          count: 1,
+        });
+      }
+    }
+    for (const value of counts.values()) {
+      this.sessions.set(
+        { status: value.status, engine: value.engine },
+        value.count,
+      );
+    }
+  }
+
+  observeMessage(direction: MessageDirection): void {
+    if (!this.messages) {
+      return;
+    }
+    this.messages.inc({ direction: direction });
+  }
+
+  render(): Promise<string> {
+    return this.register.metrics();
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3186,6 +3186,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/api@npm:^1.4.0":
+  version: 1.9.1
+  resolution: "@opentelemetry/api@npm:1.9.1"
+  checksum: 10/b26032739d3c54ca99b5a2920844a1fbd4c3ee383cacbb0915e8c706a2626fe91e96feaa6e893397abe0545dc8d0a765b220aa18a31b1773176eeaf3a225e10e
+  languageName: node
+  linkType: hard
+
 "@oxlint/darwin-arm64@npm:1.13.0":
   version: 1.13.0
   resolution: "@oxlint/darwin-arm64@npm:1.13.0"
@@ -5655,6 +5662,13 @@ __metadata:
   dependencies:
     file-uri-to-path: "npm:1.0.0"
   checksum: 10/593d5ae975ffba15fbbb4788fe5abd1e125afbab849ab967ab43691d27d6483751805d98cb92f7ac24a2439a8a8678cd0131c535d5d63de84e383b0ce2786133
+  languageName: node
+  linkType: hard
+
+"bintrees@npm:1.0.2":
+  version: 1.0.2
+  resolution: "bintrees@npm:1.0.2"
+  checksum: 10/071896cea5ea5413316c8436e95799444c208630d5c539edd8a7089fc272fc5d3634aa4a2e4847b28350dda1796162e14a34a0eda53108cc5b3c2ff6a036c1fa
   languageName: node
   linkType: hard
 
@@ -11636,6 +11650,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prom-client@npm:^15.1.3":
+  version: 15.1.3
+  resolution: "prom-client@npm:15.1.3"
+  dependencies:
+    "@opentelemetry/api": "npm:^1.4.0"
+    tdigest: "npm:^0.1.1"
+  checksum: 10/eba75e15ab896845d39359e3a4d6f7913ea05339b3122d8dde8c8c374669ad1a1d1ab2694ab2101c420bd98086a564e4f2a18aa29018fc14a4732e57c1c19aec
+  languageName: node
+  linkType: hard
+
 "promise-inflight@npm:^1.0.1":
   version: 1.0.1
   resolution: "promise-inflight@npm:1.0.1"
@@ -13460,6 +13484,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tdigest@npm:^0.1.1":
+  version: 0.1.3
+  resolution: "tdigest@npm:0.1.3"
+  dependencies:
+    bintrees: "npm:1.0.2"
+  checksum: 10/c4a0fe3469ddc1eea56938c26215b5bd690efb93ef583872c09baf81646c15acb077d9253e72e39e2655ed140410ca901bb75b77a7d29fcecf77a2efde91e52b
+  languageName: node
+  linkType: hard
+
 "terser-webpack-plugin@npm:^5.3.11":
   version: 5.3.14
   resolution: "terser-webpack-plugin@npm:5.3.14"
@@ -14217,6 +14250,7 @@ __metadata:
     pino-pretty: "npm:^11.2.1"
     prettier: "npm:^1.19.1"
     pretty-bytes: "npm:5.6.0"
+    prom-client: "npm:^15.1.3"
     promise-retry: "npm:^2.0.1"
     protoc-gen-ts: "npm:^0.8.7"
     puppeteer: "npm:^24.31.0"


### PR DESCRIPTION
Fixes https://github.com/devlikeapro/waha/issues/2244

Not a duplicate of https://github.com/devlikeapro/waha/discussions/1158 (per-session CPU). This is a scrape endpoint for operators.

## Summary

Opt-in Prometheus text at `GET /metrics`:

- `WAHA_PROMETHEUS_ENABLED=true` (default **off** → empty 404)
- Public like `/ping` (no API key). Also excluded from Swagger basic auth (same class of issue as #1981 `/jobs`)
- `prom-client` 15.1.3 locked in `yarn.lock`
- Pino autoLogging ignores `/metrics`

## Metrics

| Name | Type | Labels |
|------|------|--------|
| `waha_up` | Gauge | — |
| `waha_process_*` / `waha_nodejs_*` | default (incl. event-loop lag, RSS) | prefix `waha_` |
| `waha_http_requests_total` | Counter | `method`, `status` |
| `waha_http_request_duration_seconds` | Histogram | `method`, `status` |
| `waha_sessions` | Gauge | `status`, `engine` (runtime sessions) |
| `waha_messages_total` | Counter | `direction` (`in` / `out`) |

No `chatId`, session name, or path labels.

## Test plan

```bash
yarn jest --selectProjects unit --runTestsByPath \
  src/core/metrics/waha.metrics.test.ts \
  src/core/metrics/swagger-auth.exclude.test.ts \
  src/config.service.test.ts \
  src/core/metrics/prometheus.registry.test.ts \
  src/api/metrics.controller.test.ts \
  src/core/metrics/http.metrics.middleware.test.ts \
  src/core/metrics/session.metrics.test.ts \
  src/core/metrics/message.metrics.test.ts
```

Enable at runtime:

```bash
WAHA_PROMETHEUS_ENABLED=true
# GET /metrics → text/plain; version=0.0.4
```

Do not expose `/metrics` on the public internet; scrape from ClusterIP / NetworkPolicy.

## Follow-up (not this PR)

- Observability page on `devlikeapro/waha-docs`
- Optional scrape bearer `WAHA_PROMETHEUS_BEARER`
- Per-session CPU (discussion 1158)