### PR TITLE
fix(chatwoot): name LID contacts by push name instead of their raw id

### DIFF
--- a/src/apps/chatwoot/contacts/WhatsAppContactInfo.ts
+++ b/src/apps/chatwoot/contacts/WhatsAppContactInfo.ts
@@ -40,6 +40,30 @@ abstract class ChatContactInfo implements ContactInfo {
 }
 
 /**
+ * The display name for a chat, in the order that degrades best for an agent:
+ * the saved contact name, then the push name WhatsApp sends with every message,
+ * and only then the raw chat id.
+ *
+ * Shared by JID and LID contacts on purpose. It used to live inline in
+ * `JidContactInfo` only, so a LID with no phone number behind it — the normal
+ * case for anyone not in the address book — was named after its own id.
+ */
+async function resolveContactName(
+  session: WAHASessionAPI,
+  chatId: string,
+): Promise<string> {
+  let contact: any = null;
+  try {
+    contact = await session.getContact(chatId);
+  } catch (error) {
+    // A contact that cannot be read is no reason to fail creating it: the
+    // conversation is already arriving and it has to land somewhere.
+    contact = null;
+  }
+  return contact?.name || contact?.pushName || contact?.pushname || chatId;
+}
+
+/**
  * Regular JID contact info
  */
 class JidContactInfo extends ChatContactInfo {
@@ -67,9 +91,7 @@ class JidContactInfo extends ChatContactInfo {
   }
 
   async PublicContactCreate(): Promise<Contact> {
-    const contact: any = await this.session.getContact(this.chatId);
-    const name =
-      contact?.name || contact?.pushName || contact?.pushname || this.chatId;
+    const name = await resolveContactName(this.session, this.chatId);
     const phoneNumberE164 = E164Parser.fromJid(this.chatId);
 
     const result: Contact = {
@@ -135,10 +157,19 @@ class LidContactInfo extends ChatContactInfo {
     if (jid) {
       result = await jid.PublicContactCreate();
     } else {
+      // No phone number for this LID: WhatsApp only maps a LID to a phone number
+      // for contacts already in the address book, so `findPNByLid` returns null
+      // for anyone else — and that is by design, not a failure.
+      //
+      // The push name, however, IS available. It travels on every incoming
+      // message (`_data.Info.PushName`) and WAHA already exposes it through
+      // `getContact`. Falling straight through to the raw chat id made every
+      // unknown sender arrive in Chatwoot named `1234567890@lid`, with no name
+      // and no number — unusable for an agent answering the conversation.
       result = {
         inbox_id: 0,
         identifier: this.chatId,
-        name: this.chatId,
+        name: await resolveContactName(this.session, this.chatId),
       };
     }
     result.custom_attributes = await this.Attributes();


### PR DESCRIPTION
## The problem

When someone who is **not in the address book** messages a session, WhatsApp addresses them by LID and `findPNByLid` returns `null` — by design, since the LID exists to mask the phone number.

`LidContactInfo.PublicContactCreate()` falls straight through to the chat id in that case:

```ts
const jid = await this.jid();
if (jid) {
  result = await jid.PublicContactCreate();
} else {
  result = { inbox_id: 0, identifier: this.chatId, name: this.chatId };
}
```

So the contact lands in Chatwoot named `1234567890@lid`, with **no name and no number**. An agent opening the conversation has nothing to identify who is writing.

## The push name is right there

It travels on every incoming message and WAHA already exposes it. Verified against a live **GOWS 2026.8.1** session:

```
GET /api/{session}/chats/{lid}/messages
  _data.Info.PushName       = "Julián Valdés"     ← the name, present
  _data.Info.SenderAlt      = ""                   ← the number, empty
  _data.Info.AddressingMode = ""

GET /api/contacts?contactId={lid}
  {"id":"...@lid", "name":"", "pushname":"Julián Valdés"}

GET /api/{session}/lids/{lid}
  {"lid":"...", "pn": null}
```

The phone number genuinely is not there and cannot be recovered — that is WhatsApp's design and this PR does not try to change it. **The name is there, and was being discarded.**

## The change

`JidContactInfo` already resolved the name correctly:

```ts
const name = contact?.name || contact?.pushName || contact?.pushname || this.chatId;
```

That resolution moves to a small shared helper, and the LID branch uses it too. Both paths now degrade the same way: **saved name → push name → raw id**.

The helper swallows a failed `getContact`: a contact that cannot be read is no reason to fail creating it, since the conversation is already arriving and has to land somewhere. That matches the previous behaviour of the JID branch, where `getContact` returning nothing simply fell through.

## Why this is not #1907

[#1907](https://github.com/devlikeapro/waha/issues/1907) asked to force the canonical `@c.us` format and was closed as not planned. This does not ask for that: the LID addressing stays exactly as it is. It only stops throwing away a field you already receive.

It should also help the related reports where the id shows up where a name belongs: [#1493](https://github.com/devlikeapro/waha/issues/1493), [#1245](https://github.com/devlikeapro/waha/issues/1245), [#1073](https://github.com/devlikeapro/waha/issues/1073).

## Checks

`prettier --check` passes on the changed file, and it type-checks in isolation (only the expected unresolved-import errors, since the fork is a shallow clone without `node_modules`). I could not run the full build or suite locally — happy to adjust if CI disagrees.