### PR TITLE
fix(mcp): add default limit to chats-list pagination

### DIFF
--- a/src/structures/chats.dto.ts
+++ b/src/structures/chats.dto.ts
@@ -216,6 +216,11 @@ export enum ChatSortField {
 }
 
 export class ChatsPaginationParams extends PaginationParams {
+  @IsNumber()
+  @IsOptional()
+  @Type(() => Number)
+  limit?: number = 20;
+
   @ApiProperty({
     description: 'Sort by field',
     enum: ChatSortField,


### PR DESCRIPTION
## Problem

Calling the `chats-list` MCP tool without a `limit` argument fails with `SSE stream ended without a response` (see #2253).

## Root cause

`chats-list` is backed by `GetChatsParams` → `ChatsPaginationParams` → `PaginationParams` → `LimitOffsetParams`, where `limit` is optional with **no default**. Without a `limit`, `GET /api/{session}/chats` returns all chats (with full `_chat` payloads), producing a response large enough that the stateless `StreamableHTTPServerTransport` terminates the SSE stream before the client receives it.

`chats-overview` does not have this problem because `OverviewPaginationParams` already defaults `limit` to 20.

## Fix

Add a default `limit = 20` to `ChatsPaginationParams`, mirroring `OverviewPaginationParams`:

```ts
export class ChatsPaginationParams extends PaginationParams {
  @IsNumber()
  @IsOptional()
  @Type(() => Number)
  limit?: number = 20;
  ...
}
```

This is a one-line change that makes `chats-list` behave consistently with `chats-overview` when `limit` is omitted.

## Notes

- The SSE transport termination on large responses is an upstream MCP SDK behavior, not fixed here. This change mitigates it by bounding the default response size.
- No test changes included; the change is a default-value addition with no behavioral impact when `limit` is explicitly provided.

Closes #2253