### PR TITLE
[core] Add Argentine Phone Numbers app for outbound resolution

### DIFF
--- a/src/apps/app_sdk/apps/apps.ts
+++ b/src/apps/app_sdk/apps/apps.ts
@@ -1,3 +1,4 @@
+import { ArgentinePhoneNumbersAppConfig } from '@waha/apps/argentine-phone-numbers/dto/config.dto';
 import { Type } from '@nestjs/common';
 import { BrazilianPhoneNumbersAppConfig } from '@waha/apps/brazilian-phone-numbers/dto/config.dto';
 import { CallsAppConfig } from '@waha/apps/calls/dto/config.dto';
@@ -5,6 +6,7 @@ import { ChatWootAppConfig } from '@waha/apps/chatwoot/dto/config.dto';
 import { McpAppConfig } from '@waha/apps/mcp/dto/config.dto';
 
 export enum AppName {
+  argentinePhoneNumbers = 'argentine-phone-numbers',
   chatwoot = 'chatwoot',
   calls = 'calls',
   mcp = 'mcp',
@@ -17,6 +19,7 @@ export enum AppName {
  * without pulling in every app module (controllers, services, queues) - that creates require cycles.
  */
 export const AppConfigClasses: Record<AppName, Type<any>> = {
+  [AppName.argentinePhoneNumbers]: ArgentinePhoneNumbersAppConfig,
   [AppName.brazilianPhoneNumbers]: BrazilianPhoneNumbersAppConfig,
   [AppName.calls]: CallsAppConfig,
   [AppName.chatwoot]: ChatWootAppConfig,

--- a/src/apps/app_sdk/apps/registry.ts
+++ b/src/apps/app_sdk/apps/registry.ts
@@ -1,3 +1,4 @@
+import ArgentinePhoneNumbersAppModule from '@waha/apps/argentine-phone-numbers/app.module';
 import { ApiTags } from '@nestjs/swagger';
 import { AppModule } from '@waha/apps/app_sdk/apps/definition';
 import { AppApiTag } from '@waha/apps/app_sdk/apps/openapi';
@@ -11,6 +12,7 @@ import McpAppModule from '@waha/apps/mcp/app.module';
  * Add new apps here - the rest of app_sdk works off this list.
  */
 const APPS: AppModule[] = [
+  ArgentinePhoneNumbersAppModule,
   BrazilianPhoneNumbersAppModule,
   CallsAppModule,
   ChatWootAppModule,

--- a/src/apps/argentine-phone-numbers/README.md
+++ b/src/apps/argentine-phone-numbers/README.md
@@ -74,3 +74,29 @@ compare the returned identifiers. Then test one controlled send with the app
 disabled and enabled, checking recipient delivery (not just HTTP success).
 Repeat for GOWS, NOWEB, WEBJS and WPP as available. Keep personal numbers and
 session credentials out of fixtures and public logs.
+
+### Live GOWS validation — 2026-09-10
+
+Validated the compiled plugin from commit `51c0039` against a real paired
+WAHA `2026.8.2` Core / GOWS session on Linux x64, using an authorized Argentine
+test recipient. The plugin ran in a local harness with real `SessionHooks` and
+`RegisterPluginHooks`; its `checkNumberStatus` adapter called the remote WAHA
+API, and the resolved target was passed to that same session's `sendText` API.
+The app was not installed into the running worker. This verifies the resolver
+with real GOWS lookups and delivery, not the deployed app's lifecycle wiring.
+
+| Case | Result |
+| --- | --- |
+| Lookup with `54911…` | Exists; returns a LID and canonical `54911…@c.us` PN |
+| Lookup with `5411…` | Exists; returns the same LID and canonical PN |
+| Direct send to `5411…@c.us`, without plugin | HTTP 500: `no LID found for 5411…@s.whatsapp.net from server` |
+| Plugin resolves `5411…`, then send | HTTP 201; message subsequently has `ack=2`, `ackName=DEVICE` |
+| Plugin resolves `54911…`, then send | HTTP 201; message subsequently has `ack=2`, `ackName=DEVICE` |
+| Repeat resolution of the same input | Cache hit; zero additional lookup calls |
+
+The real failure was not a negative existence lookup: GOWS could resolve the
+phone through `checkNumberStatus` but could not send to the original noncanonical
+JID directly. Using the returned PN corrected the destination. The alternate
+candidate fallback remains covered by unit tests, not this real recipient.
+No live WEBJS, NOWEB or WPP coverage is claimed. Personal identifiers and raw
+responses are intentionally omitted.

--- a/src/apps/argentine-phone-numbers/README.md
+++ b/src/apps/argentine-phone-numbers/README.md
@@ -1,0 +1,76 @@
+# Argentine Phone Numbers
+
+Opt-in outbound phone resolution for Argentina. An integration can supply
+`5411XXXXXXXX` or `54911XXXXXXXX`; the app asks WhatsApp for the supplied
+number first and only tries the alternate after an explicit `numberExists: false`.
+The returned phone JID or LID is used as the destination for a single send.
+
+This uses the session plugin architecture introduced alongside
+[Brazilian Phone Numbers](https://github.com/devlikeapro/waha/pull/2180).
+It does not assume that the two variants identify the same account.
+
+## Enable
+
+Set `WAHA_APPS_ENABLED=True`. If filtering apps with `WAHA_APPS_ON`, include
+`argentine-phone-numbers`. Restart WAHA, then create the app through the Apps API:
+
+```http
+POST /api/apps
+Content-Type: application/json
+```
+
+```json
+{
+  "app": "argentine-phone-numbers",
+  "session": "default",
+  "id": "argentine_default",
+  "config": {
+    "lookup": true,
+    "strict": false,
+    "memoryTtl": "24h"
+  }
+}
+```
+
+Only one enabled instance is allowed per session. Disabling the app restores
+normal engine behavior. App configuration changes rebuild its plugin.
+
+## Behavior
+
+- Accepts international geographic phone numbers: `54` + ten national digits,
+  or `549` + ten national digits, with optional `+`, `@c.us` or
+  `@s.whatsapp.net`. Geographic prefixes start with 1, 2 or 3. This is a shape
+  check, not proof that a number or area code is assigned.
+- Works beyond Buenos Aires, including three- and four-digit area codes.
+- Does not parse local `011`, `15`, missing-country forms, non-geographic
+  numbers, device-qualified JIDs, groups, broadcasts, newsletters or LIDs.
+- Resolves message-send chat targets only. Mentions, typing, read receipts,
+  call rejection, deletion and group administration are unchanged.
+- Preserves the supplied number when a lookup fails or yields an incomplete
+  answer. Network errors do not trigger alternate-number routing or caching.
+- `strict: true` returns 422 only when both variants explicitly report absence.
+  False negatives from WhatsApp can therefore reject a valid destination.
+  By default, the original destination is retained.
+- Successful lookups are cached for `memoryTtl`; confirmed negatives for 60s.
+  Cache entries and concurrent lookups are keyed by the exact input digits,
+  never by the pair. The cache is per plugin/session and is not persisted.
+- `lookup: false` uses cached resolutions only and otherwise keeps the input.
+- No local-contact shortcut for the alternate: knowing that the alternate
+  exists does not prove the original is absent.
+
+## Validation
+
+```sh
+yarn test:unit --runInBand argentine-phone-numbers
+yarn tsc --noEmit
+```
+
+Unit tests exercise the real hook registration with a stubbed WhatsApp lookup.
+They do not establish delivery behavior for real Argentine accounts.
+
+Before claiming live engine coverage, record the WAHA version and engine,
+query both forms of an authorized test number using `checkNumberStatus`, and
+compare the returned identifiers. Then test one controlled send with the app
+disabled and enabled, checking recipient delivery (not just HTTP success).
+Repeat for GOWS, NOWEB, WEBJS and WPP as available. Keep personal numbers and
+session credentials out of fixtures and public logs.

--- a/src/apps/argentine-phone-numbers/app.module.ts
+++ b/src/apps/argentine-phone-numbers/app.module.ts
@@ -1,0 +1,26 @@
+import { AppModule } from '@waha/apps/app_sdk/apps/definition';
+import { AppName } from '@waha/apps/app_sdk/apps/apps';
+import { ArgentinePhoneNumbersAppService } from './services/ArgentinePhoneNumbersAppService';
+
+const ArgentinePhoneNumbersAppModule: AppModule = {
+  name: AppName.argentinePhoneNumbers,
+  openapi: {
+    title: 'Argentine Phone Numbers',
+    description:
+      'Resolve Argentine phone numbers with or without the mobile prefix 9.',
+  },
+  definition: {
+    plainkey: false,
+    queue: false,
+    migrations: false,
+    restartOnChange: true,
+    unique: true,
+  },
+  nestjs: {
+    imports: [],
+    controllers: [],
+    providers: [ArgentinePhoneNumbersAppService],
+  },
+  Service: ArgentinePhoneNumbersAppService,
+};
+export default ArgentinePhoneNumbersAppModule;

--- a/src/apps/argentine-phone-numbers/dto/config.dto.ts
+++ b/src/apps/argentine-phone-numbers/dto/config.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsOptional, IsString } from 'class-validator';
+import { IsDuration } from '@waha/nestjs/validation/IsDuration';
+
+export class ArgentinePhoneNumbersAppConfig {
+  @ApiProperty({
+    description:
+      'Reject with 422 only when both phone variants are confirmed absent.',
+    default: false,
+    required: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  strict?: boolean = false;
+
+  @ApiProperty({
+    description:
+      'Allow WhatsApp lookups. When disabled, only cached resolutions are used.',
+    default: true,
+    required: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  lookup?: boolean = true;
+
+  @ApiProperty({
+    description:
+      'In-memory resolution TTL. Cache is cleared when the app or session restarts.',
+    default: '24h',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @IsDuration()
+  memoryTtl?: string = '24h';
+}

--- a/src/apps/argentine-phone-numbers/plugins/ArgentinePhonePlugin.test.ts
+++ b/src/apps/argentine-phone-numbers/plugins/ArgentinePhonePlugin.test.ts
@@ -1,3 +1,4 @@
+import { WidToJIDPlugin } from '@waha/modules/waha-wid-jid/WidToJIDPlugin';
 import { ArgentinePhonePlugin } from './ArgentinePhonePlugin';
 import { ArgentinePhoneNumbersAppConfig } from '../dto/config.dto';
 import { SessionHooks } from '@waha/core/abc/session.hooks';
@@ -191,5 +192,59 @@ describe('Argentine phone resolution hooks', () => {
     const session = build({ lookup: false, strict: true });
     expect(await resolve(session)).toBe(original);
     expect(session.checkNumberStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe('engine hook integration', () => {
+  it('resolves before GOWS/NOWEB native JID conversion', async () => {
+    const session = build();
+    RegisterPluginHooks(new WidToJIDPlugin(session, logger, null, null));
+    session.checkNumberStatus
+      .mockResolvedValueOnce({ numberExists: false })
+      .mockResolvedValueOnce({
+        numberExists: true,
+        chatId: `${alternate}@c.us`,
+      });
+    expect(await resolve(session)).toBe(`${alternate}@s.whatsapp.net`);
+  });
+
+  it('does not recurse when the engine invokes the chat hook inside a lookup', async () => {
+    const session = build();
+    session.checkNumberStatus.mockImplementation(async ({ phone }) => {
+      const queried = await resolve(session, phone, 'checkNumberStatus');
+      return { numberExists: true, chatId: `${queried}@c.us` };
+    });
+    expect(await resolve(session)).toBe(`${original}@c.us`);
+    expect(session.checkNumberStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports removal of the mobile prefix as a fallback', async () => {
+    const session = build();
+    session.checkNumberStatus
+      .mockResolvedValueOnce({ numberExists: false })
+      .mockResolvedValueOnce({
+        numberExists: true,
+        chatId: `${original}@c.us`,
+      });
+    expect(await resolve(session, alternate)).toBe(`${original}@c.us`);
+    expect(session.checkNumberStatus).toHaveBeenLastCalledWith({
+      phone: original,
+      session: 'test',
+    });
+  });
+
+  it('does not share cached resolutions between sessions', async () => {
+    const first = build();
+    const second = build();
+    first.checkNumberStatus.mockResolvedValue({
+      numberExists: true,
+      chatId: '123@lid',
+    });
+    second.checkNumberStatus.mockResolvedValue({
+      numberExists: true,
+      chatId: '456@lid',
+    });
+    expect(await resolve(first)).toBe('123@lid');
+    expect(await resolve(second)).toBe('456@lid');
   });
 });

--- a/src/apps/argentine-phone-numbers/plugins/ArgentinePhonePlugin.test.ts
+++ b/src/apps/argentine-phone-numbers/plugins/ArgentinePhonePlugin.test.ts
@@ -248,3 +248,34 @@ describe('engine hook integration', () => {
     expect(await resolve(second)).toBe('456@lid');
   });
 });
+
+describe('cache lifecycle', () => {
+  it('removes expired destinations on subsequent activity without background timers', async () => {
+    jest.useFakeTimers();
+    try {
+      const session: any = {
+        name: 'test',
+        hooks: new SessionHooks(),
+        checkNumberStatus: jest.fn(),
+      };
+      session.checkNumberStatus.mockResolvedValue({
+        numberExists: true,
+        chatId: '123@lid',
+      });
+      const plugin = new ArgentinePhonePlugin(
+        session,
+        logger,
+        { memoryTtl: '1s' },
+        null,
+      );
+      RegisterPluginHooks(plugin);
+      await resolve(session);
+      jest.advanceTimersByTime(61000);
+      await resolve(session, alternate);
+      expect((plugin as any).memory.keys()).toEqual([alternate]);
+      expect(jest.getTimerCount()).toBe(0);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/src/apps/argentine-phone-numbers/plugins/ArgentinePhonePlugin.test.ts
+++ b/src/apps/argentine-phone-numbers/plugins/ArgentinePhonePlugin.test.ts
@@ -1,0 +1,195 @@
+import { ArgentinePhonePlugin } from './ArgentinePhonePlugin';
+import { ArgentinePhoneNumbersAppConfig } from '../dto/config.dto';
+import { SessionHooks } from '@waha/core/abc/session.hooks';
+import { RegisterPluginHooks } from '@waha/core/abc/session.plugin.hooks';
+
+const original = '541112345678';
+const alternate = '5491112345678';
+const logger: any = { warn: jest.fn() };
+
+function build(config: Partial<ArgentinePhoneNumbersAppConfig> = {}) {
+  const session: any = {
+    name: 'test',
+    hooks: new SessionHooks(),
+    checkNumberStatus: jest.fn(),
+  };
+  const plugin = new ArgentinePhonePlugin(
+    session,
+    logger,
+    Object.assign(new ArgentinePhoneNumbersAppConfig(), config),
+    null,
+  );
+  RegisterPluginHooks(plugin);
+  return session;
+}
+function resolve(session: any, phone = original, method = 'sendText') {
+  return session.hooks.wid.chat.promise(phone, method);
+}
+
+describe('Argentine phone resolution hooks', () => {
+  afterEach(() => jest.useRealTimers());
+
+  it('uses and caches the original result without looking up the alternate', async () => {
+    const session = build();
+    session.checkNumberStatus.mockResolvedValue({
+      numberExists: true,
+      chatId: `${original}@c.us`,
+    });
+    expect(await resolve(session)).toBe(`${original}@c.us`);
+    expect(await resolve(session, `+${original}@c.us`)).toBe(
+      `${original}@c.us`,
+    );
+    expect(session.checkNumberStatus.mock.calls).toEqual([
+      [{ phone: original, session: 'test' }],
+    ]);
+  });
+
+  it('tries the alternate only after explicit absence, preserving the returned LID', async () => {
+    const session = build();
+    session.checkNumberStatus
+      .mockResolvedValueOnce({ numberExists: false })
+      .mockResolvedValueOnce({ numberExists: true, chatId: '123456@lid' });
+    expect(await resolve(session)).toBe('123456@lid');
+    expect(await resolve(session)).toBe('123456@lid');
+    expect(session.checkNumberStatus.mock.calls).toEqual([
+      [{ phone: original, session: 'test' }],
+      [{ phone: alternate, session: 'test' }],
+    ]);
+  });
+
+  it('prefers the returned PN when both identifiers are available', async () => {
+    const session = build();
+    session.checkNumberStatus.mockResolvedValue({
+      numberExists: true,
+      chatId: '123@lid',
+      pn: `${alternate}@c.us`,
+    });
+    expect(await resolve(session)).toBe(`${alternate}@c.us`);
+  });
+
+  it('keeps both existing accounts distinct, including simultaneous first lookups', async () => {
+    const session = build();
+    session.checkNumberStatus.mockImplementation(async ({ phone }) => ({
+      numberExists: true,
+      chatId: `${phone}@c.us`,
+    }));
+    expect(
+      await Promise.all([resolve(session), resolve(session, alternate)]),
+    ).toEqual([`${original}@c.us`, `${alternate}@c.us`]);
+    expect(await resolve(session)).toBe(`${original}@c.us`);
+    expect(await resolve(session, alternate)).toBe(`${alternate}@c.us`);
+    expect(session.checkNumberStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it('shares concurrent lookups for the same input', async () => {
+    const session = build();
+    session.checkNumberStatus.mockResolvedValue({
+      numberExists: true,
+      chatId: `${original}@c.us`,
+    });
+    await Promise.all([resolve(session), resolve(session), resolve(session)]);
+    expect(session.checkNumberStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retarget or cache a timeout, even in strict mode', async () => {
+    const session = build({ strict: true });
+    session.checkNumberStatus.mockRejectedValue(new Error('timeout'));
+    expect(await resolve(session)).toBe(original);
+    expect(await resolve(session)).toBe(original);
+    expect(session.checkNumberStatus).toHaveBeenCalledTimes(2);
+    expect(session.checkNumberStatus).toHaveBeenLastCalledWith({
+      phone: original,
+      session: 'test',
+    });
+  });
+
+  it.each([
+    undefined,
+    {},
+    { numberExists: true },
+    { numberExists: true, chatId: '' },
+  ])('does not treat an incomplete response as absence: %j', async (answer) => {
+    const session = build({ strict: true });
+    session.checkNumberStatus.mockResolvedValue(answer);
+    expect(await resolve(session)).toBe(original);
+    expect(session.checkNumberStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the input if the alternate lookup fails after original absence', async () => {
+    const session = build({ strict: true });
+    session.checkNumberStatus
+      .mockResolvedValueOnce({ numberExists: false })
+      .mockRejectedValueOnce(new Error('timeout'));
+    expect(await resolve(session)).toBe(original);
+  });
+
+  it('keeps unresolved input in soft mode and expires negative entries', async () => {
+    jest.useFakeTimers();
+    const session = build();
+    session.checkNumberStatus.mockResolvedValue({ numberExists: false });
+    expect(await resolve(session)).toBe(original);
+    expect(await resolve(session, `+${original}@c.us`)).toBe(
+      `+${original}@c.us`,
+    );
+    expect(session.checkNumberStatus).toHaveBeenCalledTimes(2);
+    jest.advanceTimersByTime(61000);
+    await resolve(session);
+    expect(session.checkNumberStatus).toHaveBeenCalledTimes(4);
+  });
+
+  it('rejects confirmed absence in strict mode, including cached absence', async () => {
+    const session = build({ strict: true });
+    session.checkNumberStatus.mockResolvedValue({ numberExists: false });
+    await expect(resolve(session)).rejects.toMatchObject({ status: 422 });
+    await expect(resolve(session)).rejects.toMatchObject({ status: 422 });
+    expect(session.checkNumberStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it('expires positive cache entries', async () => {
+    jest.useFakeTimers();
+    const session = build({ memoryTtl: '1s' });
+    session.checkNumberStatus.mockResolvedValue({
+      numberExists: true,
+      chatId: `${original}@c.us`,
+    });
+    await resolve(session);
+    jest.advanceTimersByTime(1001);
+    await resolve(session);
+    expect(session.checkNumberStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    'rejectCall',
+    'deleteMessage',
+    'sendSeen',
+    'startTyping',
+    'checkNumberStatus',
+    'findLIDByPhoneNumber',
+    'addParticipants',
+  ])('leaves %s unchanged even after caching a rewrite', async (method) => {
+    const session = build();
+    session.checkNumberStatus.mockResolvedValue({
+      numberExists: true,
+      chatId: `${alternate}@c.us`,
+    });
+    await resolve(session);
+    expect(await resolve(session, original, method)).toBe(original);
+    expect(session.checkNumberStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves mentions, foreign numbers and LIDs untouched', async () => {
+    const session = build();
+    expect(await session.hooks.wid.mention.promise(original, 'sendText')).toBe(
+      original,
+    );
+    expect(await resolve(session, '5511912345678')).toBe('5511912345678');
+    expect(await resolve(session, `${alternate}@lid`)).toBe(`${alternate}@lid`);
+    expect(session.checkNumberStatus).not.toHaveBeenCalled();
+  });
+
+  it('does not query when lookup is disabled', async () => {
+    const session = build({ lookup: false, strict: true });
+    expect(await resolve(session)).toBe(original);
+    expect(session.checkNumberStatus).not.toHaveBeenCalled();
+  });
+});

--- a/src/apps/argentine-phone-numbers/plugins/ArgentinePhonePlugin.ts
+++ b/src/apps/argentine-phone-numbers/plugins/ArgentinePhonePlugin.ts
@@ -36,6 +36,7 @@ export class ArgentinePhonePlugin extends SessionPlugin<
   ArgentinePhoneNumbersAppConfig
 > {
   private memory: NodeCache;
+  private lastSweep = 0;
   private inflight = new Map<string, Promise<string | null>>();
 
   constructor(
@@ -71,6 +72,15 @@ export class ArgentinePhonePlugin extends SessionPlugin<
     // Key by the supplied phone, not by the pair: both variants may resolve
     // independently. Never overwrite the alternate's cache entry.
     const key = candidates[0];
+    // Sweep on activity instead of creating a timer that outlives the plugin.
+    // Expired destinations that are never queried again must also be removed.
+    const now = Date.now();
+    if (now - this.lastSweep >= 60000) {
+      for (const cachedKey of this.memory.keys()) {
+        this.memory.get(cachedKey);
+      }
+      this.lastSweep = now;
+    }
     const cached = this.memory.get<string>(key);
     if (cached !== undefined) {
       return this.fromCache(cached, wid);

--- a/src/apps/argentine-phone-numbers/plugins/ArgentinePhonePlugin.ts
+++ b/src/apps/argentine-phone-numbers/plugins/ArgentinePhonePlugin.ts
@@ -1,0 +1,136 @@
+import { UnprocessableEntityException } from '@nestjs/common';
+import { WhatsappSession } from '@waha/core/abc/session.abc';
+import { SessionPlugin } from '@waha/core/abc/session.plugin';
+import { PluginHook } from '@waha/core/abc/session.plugin.hooks';
+import { parseDurationMs } from '@waha/nestjs/validation/IsDuration';
+import { ArgentinePhoneNumbersAppConfig } from '../dto/config.dto';
+import { argentinePhoneCandidates } from '../utils/arPhone';
+import * as NodeCache from 'node-cache';
+import { Logger } from 'pino';
+
+// Identity-sensitive operations (e.g. rejectCall, deleteMessage) must pass through.
+// This allowlist also prevents recursion from WPP's checkNumberStatus hook.
+const SEND_METHODS = new Set([
+  'sendText',
+  'sendImage',
+  'sendFile',
+  'sendVideo',
+  'sendVoice',
+  'sendMedia',
+  'sendPoll',
+  'sendList',
+  'sendButtons',
+  'sendButtonsReply',
+  'sendContactVCard',
+  'sendLocation',
+  'sendLinkPreview',
+  'sendLinkCustomPreview',
+  'sendEvent',
+  'reply',
+  'forwardMessage',
+]);
+const NOT_FOUND = '';
+const NEGATIVE_TTL_SECONDS = 60;
+
+export class ArgentinePhonePlugin extends SessionPlugin<
+  ArgentinePhoneNumbersAppConfig
+> {
+  private memory: NodeCache;
+  private inflight = new Map<string, Promise<string | null>>();
+
+  constructor(
+    session: WhatsappSession,
+    logger: Logger,
+    config: ArgentinePhoneNumbersAppConfig,
+    deps: null,
+  ) {
+    super(
+      session,
+      logger,
+      config ?? new ArgentinePhoneNumbersAppConfig(),
+      deps,
+    );
+    this.memory = new NodeCache({
+      stdTTL: Math.max(
+        1,
+        Math.ceil((parseDurationMs(this.config.memoryTtl) ?? 86400000) / 1000),
+      ),
+      checkperiod: 0,
+    });
+  }
+
+  @PluginHook((hooks) => hooks.wid.chat)
+  async resolveChatWid(wid: string, method: string): Promise<string> {
+    if (!SEND_METHODS.has(method)) {
+      return wid;
+    }
+    const candidates = argentinePhoneCandidates(wid);
+    if (!candidates) {
+      return wid;
+    }
+    // Key by the supplied phone, not by the pair: both variants may resolve
+    // independently. Never overwrite the alternate's cache entry.
+    const key = candidates[0];
+    const cached = this.memory.get<string>(key);
+    if (cached !== undefined) {
+      return this.fromCache(cached, wid);
+    }
+    if (this.config.lookup === false) {
+      return wid;
+    }
+    let pending = this.inflight.get(key);
+    if (!pending) {
+      pending = this.lookup(candidates).finally(() =>
+        this.inflight.delete(key),
+      );
+      this.inflight.set(key, pending);
+    }
+    const resolved = await pending;
+    return this.fromCache(resolved, wid);
+  }
+
+  private fromCache(resolved: string | null, wid: string): string {
+    if (resolved === NOT_FOUND) {
+      if (this.config.strict) {
+        throw new UnprocessableEntityException(
+          'Neither Argentine phone number variant exists on WhatsApp.',
+        );
+      }
+      return wid;
+    }
+    return resolved ?? wid;
+  }
+
+  private async lookup(candidates: string[]): Promise<string | null> {
+    const key = candidates[0];
+    for (const phone of candidates) {
+      try {
+        const result = await this.session.checkNumberStatus({
+          phone: phone,
+          session: this.session.name,
+        });
+        if (result?.numberExists) {
+          const chatId = result.pn || result.chatId;
+          if (!chatId) {
+            // A positive result without an address is not evidence of absence.
+            return null;
+          }
+          this.memory.set(key, chatId);
+          return chatId;
+        }
+        if (result?.numberExists !== false) {
+          return null;
+        }
+      } catch {
+        // A timeout for the original must not retarget a possibly valid account.
+        this.logger.warn(
+          'Argentine phone lookup failed; keeping the original destination.',
+        );
+        return null;
+      }
+    }
+    this.memory.set(key, NOT_FOUND, NEGATIVE_TTL_SECONDS);
+    this.logger.warn('Neither Argentine phone variant was found on WhatsApp.');
+    return NOT_FOUND;
+  }
+}

--- a/src/apps/argentine-phone-numbers/services/ArgentinePhoneNumbersAppService.ts
+++ b/src/apps/argentine-phone-numbers/services/ArgentinePhoneNumbersAppService.ts
@@ -1,0 +1,118 @@
+import { Injectable } from '@nestjs/common';
+import { App } from '@waha/apps/app_sdk/dto/app.dto';
+import { IAppService } from '@waha/apps/app_sdk/services/IAppService';
+import { PluginOptions } from '@waha/core/abc/session.plugin';
+import { ArgentinePhoneNumbersAppConfig } from '@waha/apps/argentine-phone-numbers/dto/config.dto';
+import { ArgentinePhonePlugin } from '@waha/apps/argentine-phone-numbers/plugins/ArgentinePhonePlugin';
+import { SessionManager } from '@waha/core/abc/manager.abc';
+import { WhatsappSession } from '@waha/core/abc/session.abc';
+
+@Injectable()
+export class ArgentinePhoneNumbersAppService implements IAppService {
+  validate(app: App<ArgentinePhoneNumbersAppConfig>): void {
+    // The DTO validation covers structure; no extra validation rules.
+    void app;
+    return;
+  }
+
+  async beforeCreated(app: App<ArgentinePhoneNumbersAppConfig>): Promise<void> {
+    void app;
+    return;
+  }
+
+  async beforeEnabled(
+    manager: SessionManager,
+    savedApp: App<ArgentinePhoneNumbersAppConfig>,
+    newApp: App<ArgentinePhoneNumbersAppConfig>,
+  ): Promise<void> {
+    void manager;
+    void savedApp;
+    void newApp;
+  }
+
+  async beforeDisabled(
+    manager: SessionManager,
+    savedApp: App<ArgentinePhoneNumbersAppConfig>,
+    newApp: App<ArgentinePhoneNumbersAppConfig>,
+  ): Promise<void> {
+    void manager;
+    void savedApp;
+    void newApp;
+  }
+
+  async beforeUpdated(
+    manager: SessionManager,
+    savedApp: App<ArgentinePhoneNumbersAppConfig>,
+    newApp: App<ArgentinePhoneNumbersAppConfig>,
+  ): Promise<void> {
+    void manager;
+    void savedApp;
+    void newApp;
+  }
+
+  async beforeDeleted(
+    manager: SessionManager,
+    app: App<ArgentinePhoneNumbersAppConfig>,
+  ): Promise<void> {
+    void manager;
+    void app;
+  }
+
+  async afterCreated(
+    manager: SessionManager,
+    app: App<ArgentinePhoneNumbersAppConfig>,
+  ): Promise<void> {
+    void manager;
+    void app;
+  }
+
+  async beforeSessionDeleted(
+    manager: SessionManager,
+    app: App<ArgentinePhoneNumbersAppConfig>,
+  ): Promise<void> {
+    void manager;
+    void app;
+  }
+
+  async purge(
+    manager: SessionManager,
+    app: App<ArgentinePhoneNumbersAppConfig>,
+  ): Promise<void> {
+    void manager;
+    void app;
+  }
+
+  async enrich(
+    manager: SessionManager,
+    app: App<ArgentinePhoneNumbersAppConfig>,
+  ): Promise<void> {
+    void manager;
+    void app;
+  }
+
+  plugins(
+    app: App<ArgentinePhoneNumbersAppConfig>,
+    session: WhatsappSession,
+  ): PluginOptions[] {
+    void session;
+    return [ArgentinePhonePlugin.with(app.config, null)];
+  }
+
+  beforeSessionStart(
+    app: App<ArgentinePhoneNumbersAppConfig>,
+    session: WhatsappSession,
+  ): void {
+    void app;
+    void session;
+    return;
+  }
+
+  afterSessionStart(
+    app: App<ArgentinePhoneNumbersAppConfig>,
+    session: WhatsappSession,
+  ): void {
+    void app;
+    void session;
+    return;
+  }
+}

--- a/src/apps/argentine-phone-numbers/utils/arPhone.test.ts
+++ b/src/apps/argentine-phone-numbers/utils/arPhone.test.ts
@@ -1,0 +1,32 @@
+import { argentinePhoneCandidates } from './arPhone';
+
+describe('Argentine phone candidates', () => {
+  it.each([
+    ['541112345678', ['541112345678', '5491112345678']],
+    ['+5491112345678@c.us', ['5491112345678', '541112345678']],
+    ['543511234567@s.whatsapp.net', ['543511234567', '5493511234567']],
+    ['5492920123456', ['5492920123456', '542920123456']],
+  ])('keeps the original first for %s', (input, expected) => {
+    expect(argentinePhoneCandidates(input)).toEqual(expected);
+  });
+
+  it.each([
+    '0111512345678',
+    '1112345678',
+    '91112345678',
+    '54111512345678',
+    '548001234567',
+    '54911123',
+    '54911123456789',
+    '5511912345678',
+    '5491112345678@lid',
+    '5491112345678@g.us',
+    '5491112345678@newsletter',
+    '5491112345678@broadcast',
+    '5491112345678:2@s.whatsapp.net',
+    'me',
+    '',
+  ])('does not interpret %s as an international geographic phone', (input) => {
+    expect(argentinePhoneCandidates(input)).toBeNull();
+  });
+});

--- a/src/apps/argentine-phone-numbers/utils/arPhone.ts
+++ b/src/apps/argentine-phone-numbers/utils/arPhone.ts
@@ -1,0 +1,13 @@
+/** Only international geographic numbers; never interpret local 011/15 forms. */
+export function argentinePhoneCandidates(wid: string): string[] | null {
+  const match = /^\+?(54(?:9)?[1-3]\d{9})(?:@(c\.us|s\.whatsapp\.net))?$/.exec(
+    wid,
+  );
+  if (!match) {
+    return null;
+  }
+  const digits = match[1];
+  const alternate =
+    digits.length === 13 ? `54${digits.slice(3)}` : `549${digits.slice(2)}`;
+  return [digits, alternate];
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -48,7 +48,7 @@ function getPlatform() {
 }
 
 export const VERSION: WAHAEnvironment = {
-  version: '2026.8.2',
+  version: '2026.9.1',
   engine: getEngineName(),
   tier: getWAHAVersion(),
   browser: getBrowser(),


### PR DESCRIPTION
## Problem and behavior

On a real GOWS session (WAHA 2026.8.2), sending directly to `5411XXXXXXXX@c.us` failed with HTTP 500 (`no LID found`), even though `checkNumberStatus` resolved that phone to the canonical `54911XXXXXXXX@c.us` PN and a LID. Passing the canonical PN to `sendText` succeeded and received a DEVICE acknowledgement.

Integrations may supply Argentine destinations as `54 + national number` or `549 + national number`. This adds an opt-in `argentine-phone-numbers` app that resolves the supplied phone through `checkNumberStatus` before sending. It tries the other form only after WhatsApp explicitly reports that the original does not exist, then sends once to the returned PN/JID or LID.

For example, if `5411XXXXXXXX` is absent and `54911XXXXXXXX` resolves, the send uses the returned identifier. If the original exists, it wins. Both forms may resolve independently: cache entries and concurrent lookups are keyed by the original input, not the candidate pair.

This follows the apps/session-plugin direction described in #2180. It uses existing hooks and engine interfaces; there are no engine changes or new HTTP endpoints.

## Scope

- International geographic Argentine numbers, including area codes beyond Buenos Aires; optional `+`, `@c.us` and `@s.whatsapp.net`.
- Per-session app, disabled unless installed/enabled, with `lookup`, `strict` and `memoryTtl` configuration.
- Successful in-memory cache (24h default), brief confirmed-negative cache, and deduplicated lookups per input. No database migration or persistent cache in this first version.
- Timeouts and incomplete lookup answers preserve the original destination and are not cached. Strict mode returns 422 only after both candidates explicitly report absence.
- Message-send chat targets only. No changes to mentions, incoming identifiers, call rejection, deletion, read/presence or group administration. The allowlist also prevents recursive WPP lookups.
- No inference from local `011`/`15` forms or missing country codes, and no alternate-contact shortcut that would bypass checking the original.

Configuration and a reproducible live validation procedure are in `src/apps/argentine-phone-numbers/README.md`.

## Validation

- `yarn test:unit --runInBand argentine-phone-numbers`: **47 passed**. Includes real hook registration, native JID conversion, recursive lookup prevention, separate accounts/caches, concurrent queries, LIDs, expiry without background timers, negative results and transient failures.
- `yarn tsc --noEmit`: passed.
- Scoped `yarn oxlint --deny-warnings`: passed.
- `yarn build`: passed.
- Brazilian regression suites: 26 failed / 19 passed. Reproduced the same 26 failures in a clean worktree at upstream `92c7923c35cbb8e5975f30fec66440b571c2c12f`: test sessions omit `media.events`, and two repository date tests fail. These files are unchanged.
- Docker (Linux ARM64 / Node 24): `docker buildx build --target build --output type=cacheonly .` passed on the final code. The complete build stage was rebuilt; no runtime image was exported or deployed. An earlier image-export attempt was canceled after compilation while exporting layers.

## Live validation — 2026-09-10

Tested the compiled plugin at `51c0039` with real `SessionHooks` / `RegisterPluginHooks`, using a remote API adapter to a paired WAHA 2026.8.2 Core / GOWS session (Linux x64). The resolved destination was sent through that same session's `sendText` endpoint. The running worker was not changed or restarted: this exercises resolver integration with real WhatsApp lookup and delivery, **not installation/lifecycle of the app inside the worker**.

| Case | Observed result |
| --- | --- |
| `checkNumberStatus` with/without `9` | Both returned the same LID and canonical `54911…@c.us` PN |
| Direct send without plugin to `5411…@c.us` | HTTP 500: `no LID found for 5411…@s.whatsapp.net from server` |
| Plugin resolves input without `9`, then sends | HTTP 201; retrieved message reports `ack=2`, `ackName=DEVICE` |
| Plugin resolves input with `9`, then sends | HTTP 201; retrieved message reports `ack=2`, `ackName=DEVICE` |
| Repeat resolution of the same input | Cache hit, no additional lookup |

Two test messages reached the explicitly authorized recipient's device. All personal/session identifiers and raw responses are omitted from the PR. The README records the redacted evidence and procedure.

This recipient exercises canonicalization of a positive lookup, not the alternate-candidate fallback after absence. The fallback is unit-tested. No live WEBJS/NOWEB/WPP delivery coverage or installed-app lifecycle validation is claimed.


[![patron:PLUS](https://img.shields.io/badge/patron-PLUS-a0e6ba)](https://waha.devlike.pro/docs/how-to/plus-version/#tiers)