### PR TITLE
[core] Fix WEBJS presence subscriptions and LID lookup

### DIFF
--- a/src/core/engines/webjs/WebjsClientCore.ts
+++ b/src/core/engines/webjs/WebjsClientCore.ts
@@ -645,9 +645,20 @@ export class WebjsClientCore extends Client {
       const WidFactory = d('WAWebWidFactory');
 
       const wid = WidFactory.createWidFromWidLike(chatId);
+      const bridge = d('WAWebContactPresenceBridge');
+      if (chatId.endsWith('@g.us')) {
+        if (typeof bridge.subscribeGroupPresence === 'function') {
+          await bridge.subscribeGroupPresence(wid);
+          return;
+        }
+      } else if (typeof bridge.subscribeUserPresence === 'function') {
+        await bridge.subscribeUserPresence(wid);
+        return;
+      }
+
       const chat = d('WAWebChatCollection').ChatCollection.get(wid);
-      const tc = chat == null ? void 0 : chat.getTcToken();
-      await d('WAWebContactPresenceBridge').subscribePresence(wid, tc);
+      const tc = chat?.getTcToken();
+      await bridge.subscribePresence(wid, tc);
     }, chatId);
   }
 
@@ -664,7 +675,7 @@ export class WebjsClientCore extends Client {
         return [];
       }
       let chatstates = [];
-      if (chatId.endsWith('@c.us')) {
+      if (chatId.endsWith('@c.us') || chatId.endsWith('@lid')) {
         chatstates = [presence.chatstate];
       } else {
         chatstates = presence.chatstates.getModelsArray();


### PR DESCRIPTION
Opening a chat can trigger HTTP 500 responses from both `GET /api/{session}/presence/{chatId}` and `POST /api/{session}/presence/{chatId}/subscribe` with `TypeError: d(...).subscribePresence is not a function` on current WhatsApp Web.

Use `WAWebContactPresenceBridge.subscribeUserPresence` for individual contacts and `subscribeGroupPresence` for groups when available, retaining the legacy `subscribePresence(wid, tc)` fallback. Read `@lid` contact presence from the individual chat state, as for `@c.us`, instead of treating it as a group.

Validation:
- Compatibility checks for modern and legacy subscription APIs, LID/phone/group presence lookup, and missing presence records.
- Live WEBJS verification on WAHA 2026.8.2: contact and group subscription endpoints returned HTTP 201; presence retrieval returned HTTP 200 after deploying the fix and restarting the container. The default session returned to WORKING.
- Oxlint: no warnings or errors; `git diff --check` passed.
