### PR TITLE
[core] Fix native Chatwoot outgoing message delivery status

### DIFF
--- a/src/apps/chatwoot/client/Conversation.ts
+++ b/src/apps/chatwoot/client/Conversation.ts
@@ -1,5 +1,6 @@
 import ChatwootClient from '@figuro/chatwoot-sdk';
 import type { conversation_message_create } from '@figuro/chatwoot-sdk/dist/models/conversation_message_create';
+import type { conversation_message_update } from '@figuro/chatwoot-sdk/dist/models/conversation_message_update';
 import { MessageType } from '@waha/apps/chatwoot/client/types';
 
 export class Conversation {
@@ -41,6 +42,23 @@ export class Conversation {
       data = { ...data, ...this.overrideIncoming };
     }
     return this.send(data);
+  }
+
+  public async updateMessageStatus(
+    messageId: number,
+    status: 'delivered' | 'read',
+  ) {
+    // The SDK supports PATCH but its generated model omits Chatwoot's status field.
+    const data: conversation_message_update & { status: 'delivered' | 'read' } =
+      {
+        status: status,
+      };
+    return this.accountAPI.messages.update({
+      accountId: this.accountId,
+      conversationId: this.conversationId,
+      messageId: messageId,
+      data: data,
+    });
   }
 
   public async activity(text: string) {

--- a/src/apps/chatwoot/consumers/inbox/message_created.ts
+++ b/src/apps/chatwoot/consumers/inbox/message_created.ts
@@ -38,9 +38,9 @@ import {
 } from '@waha/apps/chatwoot/dto/config.dto';
 import { Locale } from '@waha/apps/chatwoot/i18n/locale';
 import { isJidGroup } from '@waha/core/utils/jids';
+import { MessageStatusService } from '@waha/apps/chatwoot/services/MessageStatusService';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const mime = require('mime-types');
+import * as mime from 'mime-types';
 
 @Processor(QueueName.INBOX_MESSAGE_CREATED, { concurrency: JOB_CONCURRENCY })
 export class ChatWootInboxMessageCreatedConsumer extends ChatWootInboxMessageConsumer {
@@ -65,6 +65,7 @@ export class ChatWootInboxMessageCreatedConsumer extends ChatWootInboxMessageCon
       session,
       container.ChatWootConfig(),
       container.Locale(),
+      container.MessageStatusService(),
     );
     return await handler.handle(body);
   }
@@ -77,6 +78,7 @@ export class MessageHandler {
     private session: WAHASessionAPI,
     private config: ChatWootConfig,
     private l: Locale,
+    private statusService: MessageStatusService,
   ) {}
 
   async handle(body: any) {
@@ -114,6 +116,7 @@ export class MessageHandler {
     // Send text (Part 1 if present)
     const attachments = message.attachments || [];
     const sendText = content && attachments.length !== 1;
+    const expectedParts = attachments.length + (sendText ? 1 : 0);
     if (sendText) {
       part += 1; // Text is the first possible part
       const exists = await this.getMapping(message, part);
@@ -129,7 +132,7 @@ export class MessageHandler {
         });
         const msg = await this.sendTextMessage(chatId, text, replyTo, mentions);
         results.push(msg);
-        await this.saveMapping(message, msg, part);
+        await this.saveMapping(message, msg, part, expectedParts);
         this.logger.info(`Text message sent: ${msg.id}`);
       }
     }
@@ -155,8 +158,14 @@ export class MessageHandler {
         `File message sent: ${msg.id} - ${file.data_url} - ${file.file_type}`,
       );
       results.push(msg);
-      await this.saveMapping(message, msg, part);
+      await this.saveMapping(message, msg, part, expectedParts);
     }
+    // Reconcile ACKs that arrived before the last mapping was committed.
+    await this.statusService.sync({
+      conversation_id: message.conversation.id,
+      message_id: message.id,
+      expected_parts: expectedParts,
+    });
     return results;
   }
 
@@ -164,11 +173,13 @@ export class MessageHandler {
     chatwootMessage: any,
     whatsappMessage: any,
     part: number,
+    expectedParts: number,
   ): Promise<void> {
     const chatwoot: Omit<ChatwootMessage, 'id'> = {
       timestamp: new Date(chatwootMessage.created_at),
       conversation_id: chatwootMessage.conversation.id,
       message_id: chatwootMessage.id,
+      expected_parts: expectedParts,
     };
     const whatsapp = EngineHelper.WhatsAppMessageKeys(whatsappMessage);
     await this.mappingService.map(chatwoot, whatsapp, part);
@@ -258,7 +269,7 @@ export class MessageHandler {
     const session = this.session;
 
     switch (file.file_type) {
-      case 'image':
+      case 'image': {
         if (mimetype != 'image/jpeg' && mimetype != 'image/png') {
           // Send it as a file
           break;
@@ -275,7 +286,8 @@ export class MessageHandler {
           mentions: mentions,
         };
         return session.sendImage(imageRequest);
-      case 'video':
+      }
+      case 'video': {
         if (mimetype != 'video/mp4') {
           break;
         }
@@ -293,7 +305,8 @@ export class MessageHandler {
           mentions: mentions,
         };
         return session.sendVideo(videoRequest);
-      case 'audio':
+      }
+      case 'audio': {
         const voiceRequest: MessageVoiceRequest = {
           session: '',
           chatId: chatId,
@@ -305,6 +318,7 @@ export class MessageHandler {
           convert: true,
         };
         return session.sendVoice(voiceRequest);
+      }
     }
     // Fallback and send as file (attachment)
     const fileRequest: MessageFileRequest = {

--- a/src/apps/chatwoot/consumers/inbox/message_updated.ts
+++ b/src/apps/chatwoot/consumers/inbox/message_updated.ts
@@ -35,6 +35,7 @@ export class ChatWootInboxMessageUpdatedConsumer extends ChatWootInboxMessageCon
       session,
       container.ChatWootConfig(),
       container.Locale(),
+      container.MessageStatusService(),
     );
     return await handler.handle(body);
   }

--- a/src/apps/chatwoot/consumers/scheduled/message.cleanup.ts
+++ b/src/apps/chatwoot/consumers/scheduled/message.cleanup.ts
@@ -44,5 +44,6 @@ export class MessageCleanupConsumer extends ChatWootScheduledConsumer {
       .MessageMappingService()
       .cleanup(removeAfter);
     logger.info(`Removed ${removed} mappings for messages`);
+    await container.MessageAckRepository().cleanup(removeAfter);
   }
 }

--- a/src/apps/chatwoot/consumers/waha/base.ts
+++ b/src/apps/chatwoot/consumers/waha/base.ts
@@ -47,14 +47,12 @@ export function ListenEventsForChatWoot(config: ChatWootConfig) {
     WAHAEvents.MESSAGE_REACTION,
     WAHAEvents.MESSAGE_EDITED,
     WAHAEvents.MESSAGE_REVOKED,
+    WAHAEvents.MESSAGE_ACK,
     WAHAEvents.SESSION_STATUS,
     WAHAEvents.CALL_RECEIVED,
     WAHAEvents.CALL_ACCEPTED,
     WAHAEvents.CALL_REJECTED,
   ];
-  if (config.conversations.markAsRead) {
-    events.push(WAHAEvents.MESSAGE_ACK);
-  }
   return events;
 }
 

--- a/src/apps/chatwoot/consumers/waha/message.ack.ts
+++ b/src/apps/chatwoot/consumers/waha/message.ack.ts
@@ -17,9 +17,14 @@ import { WAHAEvents } from '@waha/structures/enums.dto';
 import { WAHAWebhookMessageAck } from '@waha/structures/webhooks.dto';
 import { Job } from 'bullmq';
 import { PinoLogger } from 'nestjs-pino';
-import { ShouldMarkAsReadInChatWoot } from '@waha/apps/chatwoot/consumers/waha/message.ack.utils';
+import {
+  ShouldMarkAsReadInChatWoot,
+  ShouldUpdateMessageStatusInChatWoot,
+} from '@waha/apps/chatwoot/consumers/waha/message.ack.utils';
 import { parseMessageIdSerialized } from '@waha/core/utils/ids';
 import { MessageMappingService } from '@waha/apps/chatwoot/storage';
+import { MessageAckRepository } from '@waha/apps/chatwoot/storage/MessageAckRepository';
+import { MessageStatusService } from '@waha/apps/chatwoot/services/MessageStatusService';
 
 @Processor(QueueName.WAHA_MESSAGE_ACK, { concurrency: JOB_CONCURRENCY })
 export class WAHAMessageAckConsumer extends ChatWootWAHABaseConsumer {
@@ -32,7 +37,7 @@ export class WAHAMessageAckConsumer extends ChatWootWAHABaseConsumer {
   }
 
   ShouldProcess(event: any): boolean {
-    return ShouldMarkAsReadInChatWoot(event);
+    return ShouldUpdateMessageStatusInChatWoot(event);
   }
 
   GetChatId(event: WAHAWebhookMessageAck): string {
@@ -53,18 +58,16 @@ export class WAHAMessageAckConsumer extends ChatWootWAHABaseConsumer {
       info,
       session,
       container.Locale(),
+      container.MessageAckRepository(),
+      container.MessageStatusService(),
+      container.ChatWootConfig().conversations.markAsRead,
     );
-    try {
-      await handler.handle(event);
-    } catch (e) {
-      // TODO: Investigate errors
-      // https://github.com/devlikeapro/waha/issues/1492
-      this.logger.error(e);
-    }
+    // Let the existing queue retry API/storage failures instead of losing ACKs.
+    await handler.handle(event);
   }
 }
 
-class MessageAckHandler {
+export class MessageAckHandler {
   constructor(
     private readonly contactConversationService: ContactConversationService,
     protected mappingService: MessageMappingService,
@@ -72,12 +75,20 @@ class MessageAckHandler {
     private readonly info: IMessageInfo,
     private readonly session: WAHASessionAPI,
     private readonly locale: Locale,
+    private readonly acknowledgements: MessageAckRepository,
+    private readonly statusService: MessageStatusService,
+    private readonly markAsRead: boolean,
   ) {}
 
   async handle(event: WAHAWebhookMessageAck): Promise<void> {
     const payload = event.payload;
 
     const key = parseMessageIdSerialized(payload.id);
+    await this.acknowledgements.record(
+      key.id,
+      payload.ack,
+      new Date(event.timestamp),
+    );
     const chatwoot = await this.mappingService.getChatWootMessage({
       chat_id: null,
       message_id: key.id,
@@ -85,6 +96,15 @@ class MessageAckHandler {
     // No chatwoot message found, so we don't mark it as read
     // Filters out old messages and some service ack messages
     if (!chatwoot) {
+      return;
+    }
+
+    this.info.onConversationId(chatwoot.conversation_id);
+    const status = await this.statusService.sync(chatwoot);
+    if (!this.markAsRead || !ShouldMarkAsReadInChatWoot(event)) {
+      return;
+    }
+    if (chatwoot.expected_parts && status !== 'read') {
       return;
     }
 
@@ -104,7 +124,6 @@ class MessageAckHandler {
       );
       return;
     }
-    this.info.onConversationId(conversation.conversationId);
 
     const sourceId = conversation.sourceId;
     if (!sourceId) {
@@ -116,16 +135,16 @@ class MessageAckHandler {
 
     try {
       await this.contactConversationService.markConversationAsRead(
-        conversation.conversationId,
+        chatwoot.conversation_id,
         sourceId,
       );
       this.logger.info(
-        `Marked conversation ${conversation.conversationId} as read for chat.id: ${payload.from} (message: ${payload.id}, sourceId: ${sourceId})`,
+        `Marked conversation ${chatwoot.conversation_id} as read for chat.id: ${payload.from} (message: ${payload.id}, sourceId: ${sourceId})`,
       );
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error);
       this.logger.error(
-        `Error marking conversation ${conversation.conversationId} as read for chat.id: ${payload.from}. Reason: ${reason}`,
+        `Error marking conversation ${chatwoot.conversation_id} as read for chat.id: ${payload.from}. Reason: ${reason}`,
       );
       throw error;
     }

--- a/src/apps/chatwoot/consumers/waha/message.ack.utils.ts
+++ b/src/apps/chatwoot/consumers/waha/message.ack.utils.ts
@@ -1,13 +1,23 @@
 import type { WAHAWebhookMessageAck } from '@waha/structures/webhooks.dto';
 import { isJidCusFormat } from '@waha/utils/wa';
 import { WAMessageAck } from '@waha/structures/enums.dto';
-import { isLidUser, toCusFormat } from '@waha/core/utils/jids';
+import { isLidUser } from '@waha/core/utils/jids';
 import { EngineHelper } from '@waha/apps/chatwoot/waha';
 
 export function ShouldMarkAsReadInChatWoot(
   event: WAHAWebhookMessageAck,
 ): boolean {
-  // Mark as seen only if it's DM
+  return (
+    ShouldUpdateMessageStatusInChatWoot(event) &&
+    (event.payload.ack === WAMessageAck.READ ||
+      event.payload.ack === WAMessageAck.PLAYED)
+  );
+}
+
+export function ShouldUpdateMessageStatusInChatWoot(
+  event: WAHAWebhookMessageAck,
+): boolean {
+  // Track individual delivery/read status only for direct messages.
   // Ignore groups and other multiple participants chats
   const chatId = EngineHelper.ChatID(event.payload);
   if (!isJidCusFormat(chatId) && !isLidUser(chatId)) {
@@ -15,18 +25,18 @@ export function ShouldMarkAsReadInChatWoot(
   }
 
   const payload = event.payload;
-  // Only READ and PLAYED
-  const read = payload.ack === WAMessageAck.READ;
-  const played = payload.ack == WAMessageAck.PLAYED;
-  if (!read && !played) {
+  if (
+    ![WAMessageAck.DEVICE, WAMessageAck.READ, WAMessageAck.PLAYED].includes(
+      payload.ack,
+    )
+  ) {
     return false;
   }
 
-  // Only process when OUR message (fromMe: true) was read by recipient
-  if (!payload.fromMe) {
+  // Only process acknowledgements of OUR outgoing messages.
+  if (payload.fromMe !== true) {
     return false;
   }
 
-  // Mark ChatWoot conversation as read when recipient reads our message
   return true;
 }

--- a/src/apps/chatwoot/di/DIContainer.ts
+++ b/src/apps/chatwoot/di/DIContainer.ts
@@ -31,6 +31,8 @@ import {
   ConversationSort,
 } from '@waha/apps/chatwoot/services/ConversationSelector';
 import { Auth } from '@waha/core/auth/config';
+import { MessageAckRepository } from '@waha/apps/chatwoot/storage/MessageAckRepository';
+import { MessageStatusService } from '@waha/apps/chatwoot/services/MessageStatusService';
 
 /**
  * Dependency Injection Container for ChatWoot
@@ -187,6 +189,20 @@ export class DIContainer {
 
   public ChatWootErrorReporter(job: Job): ChatWootErrorReporter {
     return new ChatWootErrorReporter(this.Logger(), job, this.Locale());
+  }
+
+  @CacheSync()
+  public MessageAckRepository(): MessageAckRepository {
+    return new MessageAckRepository(this.Knex(), this.AppPk());
+  }
+
+  @CacheSync()
+  public MessageStatusService(): MessageStatusService {
+    return new MessageStatusService(
+      this.MessageMappingService(),
+      this.MessageAckRepository(),
+      this.ContactConversationService(),
+    );
   }
 
   /**

--- a/src/apps/chatwoot/migrations/002_message_delivery_status.ts
+++ b/src/apps/chatwoot/migrations/002_message_delivery_status.ts
@@ -1,0 +1,27 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex) {
+  await knex.schema.alterTable('app_chatwoot_chatwoot_messages', (table) => {
+    // Only native outbound sends know how many WhatsApp parts to expect.
+    table.integer('expected_parts').nullable();
+  });
+  await knex.schema.createTable('app_chatwoot_message_acks', (table) => {
+    table
+      .integer('app_pk')
+      .references('pk')
+      .inTable('apps')
+      .onDelete('CASCADE');
+    table.string('message_id', 64);
+    table.integer('ack').notNullable();
+    table.datetime('timestamp').notNullable();
+    table.primary(['app_pk', 'message_id']);
+    table.index(['app_pk', 'timestamp']);
+  });
+}
+
+export async function down(knex: Knex) {
+  await knex.schema.dropTable('app_chatwoot_message_acks');
+  await knex.schema.alterTable('app_chatwoot_chatwoot_messages', (table) => {
+    table.dropColumn('expected_parts');
+  });
+}

--- a/src/apps/chatwoot/services/MessageStatusService.ts
+++ b/src/apps/chatwoot/services/MessageStatusService.ts
@@ -1,0 +1,41 @@
+import { ContactConversationService } from '@waha/apps/chatwoot/client/ContactConversationService';
+import { MessageMappingService } from '@waha/apps/chatwoot/storage/MessageMappingService';
+import { MessageAckRepository } from '@waha/apps/chatwoot/storage/MessageAckRepository';
+import { ChatwootMessage } from '@waha/apps/chatwoot/storage/types';
+import { WAMessageAck } from '@waha/structures/enums.dto';
+
+export class MessageStatusService {
+  constructor(
+    private readonly mappings: MessageMappingService,
+    private readonly acknowledgements: MessageAckRepository,
+    private readonly conversations: ContactConversationService,
+  ) {}
+
+  async sync(
+    message: Pick<
+      ChatwootMessage,
+      'conversation_id' | 'message_id' | 'expected_parts'
+    >,
+  ) {
+    // Historical/imported mappings do not say whether all parts were sent.
+    if (!message.expected_parts) {
+      return null;
+    }
+    const parts = await this.mappings.getWhatsAppMessage(message);
+    if (parts.length !== message.expected_parts) {
+      return null;
+    }
+    const ack = await this.acknowledgements.minimumAck(
+      parts.map((part) => part.message_id),
+    );
+    if (ack < WAMessageAck.DEVICE) {
+      return null;
+    }
+    const status = ack >= WAMessageAck.READ ? 'read' : 'delivered';
+    // Use the mapped conversation, never the newest conversation for a contact.
+    await this.conversations
+      .ConversationById(message.conversation_id)
+      .updateMessageStatus(message.message_id, status);
+    return status;
+  }
+}

--- a/src/apps/chatwoot/storage/MessageAckRepository.ts
+++ b/src/apps/chatwoot/storage/MessageAckRepository.ts
@@ -1,0 +1,41 @@
+import { Knex } from 'knex';
+
+export class MessageAckRepository {
+  private readonly table = 'app_chatwoot_message_acks';
+
+  constructor(
+    private readonly knex: Knex,
+    private readonly appPk: number,
+  ) {}
+
+  async record(messageId: string, ack: number, timestamp: Date): Promise<void> {
+    const key = { app_pk: this.appPk, message_id: messageId };
+    // An ACK can arrive before saveMapping finishes. Keep it independently.
+    await this.knex(this.table)
+      .insert({ ...key, ack: ack, timestamp: timestamp })
+      .onConflict(['app_pk', 'message_id'])
+      .ignore();
+    await this.knex(this.table)
+      .where(key)
+      .where('ack', '<', ack)
+      .update({ ack: ack });
+  }
+
+  async minimumAck(messageIds: string[]): Promise<number> {
+    const rows = await this.knex(this.table)
+      .where({ app_pk: this.appPk })
+      .whereIn('message_id', messageIds)
+      .select('ack');
+    if (rows.length !== messageIds.length || rows.length === 0) {
+      return 0;
+    }
+    return Math.min(...rows.map((row) => row.ack));
+  }
+
+  async cleanup(removeAfter: Date): Promise<number> {
+    return this.knex(this.table)
+      .where({ app_pk: this.appPk })
+      .where('timestamp', '<', removeAfter)
+      .del();
+  }
+}

--- a/src/apps/chatwoot/storage/MessageMappingRepository.ts
+++ b/src/apps/chatwoot/storage/MessageMappingRepository.ts
@@ -77,6 +77,12 @@ export class MessageMappingRepository {
       .first();
   }
 
+  async getAllByChatwootMessageId(id: number): Promise<MessageMapping[]> {
+    return this.knex(this.tableName)
+      .where({ app_pk: this.appPk, chatwoot_message_id: id })
+      .orderBy('part', 'asc');
+  }
+
   async getByChatwootMessageIdAndPart(
     id: number,
     part: number,

--- a/src/apps/chatwoot/storage/MessageMappingService.ts
+++ b/src/apps/chatwoot/storage/MessageMappingService.ts
@@ -126,11 +126,11 @@ export class MessageMappingService {
     }
     const mappings = [];
     for (const message of messages) {
-      const mapping =
-        await this.messageMappingRepository.getByChatwootMessageId(message.id);
-      if (mapping) {
-        mappings.push(mapping);
-      }
+      const parts =
+        await this.messageMappingRepository.getAllByChatwootMessageId(
+          message.id,
+        );
+      mappings.push(...parts);
     }
     const whatsapp = [];
     for (const mapping of mappings) {

--- a/src/apps/chatwoot/storage/types.ts
+++ b/src/apps/chatwoot/storage/types.ts
@@ -15,6 +15,7 @@ export interface ChatWootCombinedKey {
 export interface ChatwootMessage extends ChatWootCombinedKey {
   id?: number;
   timestamp: Date;
+  expected_parts?: number;
 }
 
 export interface MessageMapping {


### PR DESCRIPTION
## Summary

Synchronizes native Chatwoot outbound message status from WhatsApp acknowledgements.

- Maps DEVICE acknowledgements to delivered and READ/PLAYED to read.
- Uses the persisted WhatsApp-to-Chatwoot mapping, including LID contacts, rather than content matching or a contact’s latest conversation.
- Keeps acknowledgements received before mapping persistence and reconciles them after all outbound parts are mapped.
- Waits for every multipart part and uses the lowest acknowledgement.
- Lets status-update failures reach the existing consumer retry path.

Incoming messages, group/channel receipts, and historical mappings without a known part count remain excluded.

## Reproduction

With the native Chatwoot integration, an outbound direct message can receive message.ack with DEVICE or READ while its Chatwoot status remains sent. The previous consumer only used READ/PLAYED to optionally mark a conversation as seen; it did not update the mapped Chatwoot message.

## Validation

- git diff --check
- oxlint --deny-warnings on changed TypeScript files
- Prettier check
- Isolated integration harness against the compiled application and real Chatwoot SDK HTTP calls: 16/16 scenarios in SQLite and 16/16 in PostgreSQL.

The harness covers early, duplicate, and out-of-order acknowledgements; multipart messages; application isolation; exact conversation selection; retry propagation; no resend on reconciliation; retention; and migration rollback/up.

No external WhatsApp messages were sent during validation.